### PR TITLE
removed backend service from set-fhir-user-mapping.md

### DIFF
--- a/samples/patientandpopulationservices-smartonfhir-oncg10/docs/ad-apps/set-fhir-user-mapping.md
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/docs/ad-apps/set-fhir-user-mapping.md
@@ -7,7 +7,6 @@ For testing this sample with the Inferno (g)(10) test suite, the `fhirUser` clai
 - Inferno Patient Standalone Confidential Client
 - Inferno Patient Public Confidential Client
 - Inferno EHR Launch Confidential Client
-- Backend Service Client Application
 
 
 ## Add fhirUser claim to your test users


### PR DESCRIPTION
Removing the "Backend Service Client Application" from the list for fhirUser Claims Mapping because this mapping is not required for the Backend service client.