### PR TITLE
Added Vnet support, APIM version update and upgraded SMART on FHIR sample to .NET 8

### DIFF
--- a/samples/smartonfhir/docs/deployment.md
+++ b/samples/smartonfhir/docs/deployment.md
@@ -47,7 +47,7 @@ Next you will need to clone this repository and prepare your environment for dep
     ```
     - When running this command, you must select the subscription name and location from the drop-down menus to specify the deployment location for all resources. 
     - Please be aware that this sample can only be deployed in the EastUS2, WestUS2, or CentralUS regions. Make sure you choose one of these regions during the deployment process.
-    - The azd provision command will prompt you to enter values for the `existingResourceGroupName` and `fhirid` parameters:
+    - The azd provision command will prompt you to enter values for the `existingResourceGroupName`, `fhirid` and `enableVNetSupport` parameters:
         - `existingResourceGroupName` : This parameter allows you to decide whether to deploy this sample in an existing resource group or to create a new resource group and deploy the sample. Leaving this parameter empty will create a new resource group named '{env_name}-rg' and deploy the sample. If you provide an existing resource group, the sample will be deployed in that resource group.
           - Note: If you are using an existing resource group, make sure that it does not already have a SMART on FHIR resource already deployed, because multiple samples in the same resource group are not supported.
           - Note: SMART on FHIR will need to be deployed in the same resource group as the associated FHIR server. 
@@ -55,6 +55,20 @@ Next you will need to clone this repository and prepare your environment for dep
             1. Navigate to your FHIR service in Azure Portal.
             2. Click on properties in the left menu.
             3. Copy the "Id" field under the "Essentials" group.     
+        - `enableVNetSupport`: This parameter accepts a boolean (true/false) value. 
+        
+            When set to false, the follwing resorces are deployed with mentioned configurations. User will not be able to create private endpoints and will not be able to setup private network.
+            1. API Management (APIM): Deployed in the Consumption tier.
+            2. App Service Plan : Deployed in the Dynamic tier. 
+            3. Static Web App: Deployed in the Free tier.
+            4. Function Apps and App Service Plan: Utilizes Linux as the operating system.
+        
+            When set to true, the following resources are deployed in the Standard/Premium tier to enable private endpoint creation necessary for Virtual Network Support. 
+            1. API Management (APIM): Deployed in the Premium tier.
+            2. App Service Plan and Static Web App: Deployed in the Standard tier.
+            3. Function Apps and App Service Plan: Utilizes Windows as the operating system. 
+
+          *NOTE:* This only allows you to create private endpoints, not set up the private network as part of the deployment. Users are responsible for setting up their own private networks. Make sure all resources are deployed under the same subscription and same resource group. 
         - Some important considerations when using an existing FHIR service instance:
             - The FHIR server instance and SMART on FHIR resources are expected to be deployed in the same resource group, so enter the same resource group name in the `existingResourceGroupName` parameter.
             - Enable the system-assigned status in the existing FHIR service, Follow the below steps:

--- a/samples/smartonfhir/docs/deployment.md
+++ b/samples/smartonfhir/docs/deployment.md
@@ -15,7 +15,7 @@ Make sure you have the pre-requisites listed below
   - [Azure Developer CLI Version 1.2.0 or Greater](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd?tabs=baremetal%2Cwindows) to deploy the infrastructure and code for this sample.
   - [Visual Studio](https://visualstudio.microsoft.com/), [Visual Studio Code](https://code.visualstudio.com/), or another development environment (for changing configuration debugging the sample code).
   - [Node Version 18.17.1/ NPM Version 10.2.0](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for building the frontend application and installing the US Core FHIR Profile.
-  - [.NET SDK Version 7.0.400](https://learn.microsoft.com/dotnet/core/sdk) installed (for building the sample).
+  - [.NET SDK Version 8+](https://learn.microsoft.com/dotnet/core/sdk) installed (for building the sample).
   - [PowerShell Version 5.1.22621.2428 or Greater](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) installed for running scripts (works for Mac and Linux too!).
 
 - **Access:**

--- a/samples/smartonfhir/infra/app/contextApp.bicep
+++ b/samples/smartonfhir/infra/app/contextApp.bicep
@@ -1,7 +1,11 @@
 param staticWebAppName string
 param location string
 param appTags object = {}
-param sku object = {
+param enableVNetSupport bool
+param sku object = enableVNetSupport ? {
+  name: 'Standard'
+  tier: 'Standard'
+} : {
   name: 'Free'
   tier: 'Free'
 }

--- a/samples/smartonfhir/infra/core/apiManagement.bicep
+++ b/samples/smartonfhir/infra/core/apiManagement.bicep
@@ -4,13 +4,15 @@ param apiManagementServiceName string
 @description('Location for API Management service instance.')
 param location string = resourceGroup().location
  
+param enableVNetSupport bool
+
 @description('The pricing tier of this API Management service')
 @allowed(['Consumption', 'Basic', 'Developer', 'Standard', 'Premium'])
-param sku string = 'Consumption'
+param sku string = enableVNetSupport ? 'Premium' : 'Consumption'
 
 @description('The instance size of this API Management service.')
 @allowed([0, 1, 2])
-param skuCount int = 0
+param skuCount int = enableVNetSupport ? 1 : 0
 
 @description('The name of the owner of the service')
 @minLength(1)

--- a/samples/smartonfhir/infra/core/functionHost.bicep
+++ b/samples/smartonfhir/infra/core/functionHost.bicep
@@ -2,6 +2,7 @@ param name string
 param nameCleanShort string
 param location string
 param appTags object
+param enableVNetSupport bool
 
 
 @description('Name for the storage account needed for Custom Operation Function Apps')
@@ -21,18 +22,26 @@ resource funcStorageAccount 'Microsoft.Storage/storageAccounts@2021-08-01' = {
 @description('Name for the App Service used to host Custom Operation Function Apps.')
 var customOperationsAppServiceName = '${name}-appserv'
 
+var sku = enableVNetSupport ? {
+  name: 'S1'
+  tier: 'Standard'
+} : {
+  name: 'Y1'
+  tier: 'Dynamic'
+}
+
+var properties = enableVNetSupport ? {}
+: {
+  reserved: true
+}
+
 @description('App Service used to run Azure Function')
 resource hostingPlan 'Microsoft.Web/serverfarms@2021-03-01' = {
   name: customOperationsAppServiceName
   location: location
   kind: 'functionapp'
-  sku: {
-    name: 'Y1'
-    tier: 'Dynamic'
-  }
-  properties: {
-    reserved: true
-  }
+  sku: sku
+  properties: properties
   tags: appTags
 }
 

--- a/samples/smartonfhir/infra/main.bicep
+++ b/samples/smartonfhir/infra/main.bicep
@@ -45,6 +45,9 @@ param fhirId string
 @description('Name of the Log Analytics workspace to deploy or use. Leave blank to skip deployment')
 param logAnalyticsName string = ''
 
+@description('Deploy sample with Virtual Network')
+param enableVNetSupport bool
+
 // end optional configuration parameters
 
 var nameClean = replace(name, '-', '')
@@ -126,6 +129,7 @@ module functionBase 'core/functionHost.bicep' = {
     location: location
     name: name
     nameCleanShort: nameCleanShort
+    enableVNetSupport: enableVNetSupport
   }
 }
 
@@ -159,6 +163,7 @@ module authCustomOperation './app/authCustomOperation.bicep' = {
     redisCacheId: redis.outputs.redisCacheId
     redisApiVersion: redis.outputs.redisApiVersion
     redisCacheHostName: redis.outputs.redisCacheHostName
+    enableVNetSupport: enableVNetSupport
   }
 }
 
@@ -201,6 +206,7 @@ module apim './core/apiManagement.bicep'= {
     smartAuthFunctionBaseUrl: 'https://${name}-aad-func.azurewebsites.net/api'
     contextStaticAppBaseUrl: contextStaticWebApp.outputs.uri
     appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+    enableVNetSupport: enableVNetSupport
   }
 }
 
@@ -214,6 +220,9 @@ module redisApimLink './core/apiManagement/redisExternalCache.bicep'= {
     redisCacheHostName: redis.outputs.redisCacheHostName
     redisCacheId: redis.outputs.redisCacheId
   }
+  dependsOn:[
+    apim
+  ]
 }
 
 var authorizeStaticWebAppName = '${name}-contextswa'
@@ -227,6 +236,7 @@ module contextStaticWebApp './app/contextApp.bicep' = {
     appTags: union(appTags, {
       'azd-service-name': 'context'
     })
+    enableVNetSupport: enableVNetSupport
   }
 }
 

--- a/samples/smartonfhir/infra/main.parameters.json
+++ b/samples/smartonfhir/infra/main.parameters.json
@@ -20,6 +20,9 @@
     "fhirid": {
       "value": ""
     },
+    "enableVNetSupport":{
+      "value": ""
+    },
     "location": {
       "value": "${AZURE_LOCATION}"
     },

--- a/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth.UnitTests/SMARTCustomOperations.AzureAuth.UnitTests.csproj
+++ b/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth.UnitTests/SMARTCustomOperations.AzureAuth.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateMSBuildEditorConfigFile>false</GenerateMSBuildEditorConfigFile>

--- a/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth/SMARTCustomOperations.AzureAuth.csproj
+++ b/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth/SMARTCustomOperations.AzureAuth.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.9</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -12,9 +11,9 @@
   <ItemGroup>
     <PackageReference Include="HttpMultipartParser" Version="8.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.4" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.14.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
     <PackageReference Include="Microsoft.AzureHealth.DataServices.Caching" Version="1.1.0" />
     <PackageReference Include="Microsoft.AzureHealth.DataServices.Core" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />

--- a/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth/local.settings.json
+++ b/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth/local.settings.json
@@ -1,6 +1,9 @@
 {
-    "IsEncrypted": false,
-    "Host": {
-        "CORS": "*"
-    }
+  "IsEncrypted": false,
+  "Host": {
+    "CORS": "*"
+  },
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+  }
 }


### PR DESCRIPTION
Implemented below User stories to SMART on FHIR sample

[User Story 122519: Add private link support to existing SMART on FHIR sample](https://microsofthealth.visualstudio.com/Health/_workitems/edit/122519)
[User Story 121922: [SMART on FHIR]Upgrade SMART on FHIR and ONC g(10) samples to .NET8](https://microsofthealth.visualstudio.com/Health/_workitems/edit/121922)
[User Story 122126: Documentation updates on how to use enableVNetSupport](https://microsofthealth.visualstudio.com/Health/_workitems/edit/122126)
[User Story 121921: [SMART on FHIR] Move SMART on FHIR and ONC g(10) samples off the old deprecated version of APIM](https://microsofthealth.visualstudio.com/Health/_workitems/edit/121921)