### PR TITLE
Fix: Change postprovision hook to run in PowerShell instead of Bash

### DIFF
--- a/samples/patientandpopulationservices-smartonfhir-oncg10/azure.yaml
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/azure.yaml
@@ -21,5 +21,5 @@ services:
     host: staticwebapp
 hooks:
   postprovision:
-    shell: sh
+    shell: pwsh
     run: npm run setbuildenv --prefix src/auth-context-frontend-app 

--- a/samples/smartonfhir-oncg10-consolidated/azure.yaml
+++ b/samples/smartonfhir-oncg10-consolidated/azure.yaml
@@ -21,5 +21,5 @@ services:
     host: staticwebapp
 hooks:
   postprovision:
-    shell: sh
+    shell: pwsh
     run: npm run setbuildenv --prefix src/auth-context-frontend-app

--- a/samples/smartonfhir/azure.yaml
+++ b/samples/smartonfhir/azure.yaml
@@ -17,5 +17,5 @@ services:
     host: staticwebapp
 hooks:
   postprovision:
-    shell: sh
+    shell: pwsh
     run: npm run setbuildenv --prefix src/auth-context-frontend-app 


### PR DESCRIPTION
We added a post-provision hook to address an issue where not all SMART on FHIR files were copied during deployment. It was observed that the hook failed in PowerShell but worked in Bash. Since our documentation specifies the use of PowerShell, we have updated the hook to support PowerShell exclusively, ensuring consistent behavior according to our requirements.