### PR TITLE
Appinsights connection string changes

### DIFF
--- a/samples/patientandpopulationservices-smartonfhir-oncg10/infra/app/authCustomOperation.bicep
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/infra/app/authCustomOperation.bicep
@@ -25,9 +25,6 @@ param backendServiceVaultName string
 @description('Microsoft Entra ID Application ID for the context application.')
 param contextAadApplicationId string
 
-@description('App Insights Instrumentation Key for the sample. (Optional)')
-param appInsightsInstrumentationKey string
-
 @description('App Insights Connection String for the sample. (Optional)')
 param appInsightsConnectionString string
 
@@ -108,13 +105,11 @@ resource authCustomOperationAppSettings 'Microsoft.Web/sites/config@2020-12-01' 
     // WEBSITE_CONTENTSHARE: authCustomOperationsFunctionAppName
     FUNCTIONS_EXTENSION_VERSION: '~4'
     FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-    APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
     SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
     ENABLE_ORYX_BUILD: 'true'
 
     AZURE_ApiManagementHostName: '${apimName}.azure-api.net'
-    AZURE_APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
     AZURE_APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
     AZURE_TenantId: tenantId
     AZURE_FhirAudience: fhirServiceAudience

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/infra/app/exportCustomOperation.bicep
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/infra/app/exportCustomOperation.bicep
@@ -16,9 +16,6 @@ param apimName string
 @description('URL used to access the FHIR Service by the custom operation.')
 param fhirUrl string
 
-@description('App Insights Instrumentation Key for the sample. (Optional)')
-param appInsightsInstrumentationKey string
-
 @description('App Insights Connection String for the sample. (Optional)')
 param appInsightsConnectionString string
 
@@ -87,14 +84,12 @@ resource exportCustomOperationFfhirProxyAppSettings 'Microsoft.Web/sites/config@
     // WEBSITE_CONTENTSHARE: exportCustomOperationsFunctionAppName
     FUNCTIONS_EXTENSION_VERSION: '~4'
     FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-    APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString    
     SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
     ENABLE_ORYX_BUILD: 'true'
     
     AZURE_ApiManagementHostName: '${apimName}.azure-api.net'
     AZURE_FhirUrl: fhirUrl
-    AZURE_APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
     AZURE_APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
     AZURE_TenantId: tenantId
     AZURE_ExportStorageAccountUrl: 'https://${funcStorageAccount.name}.blob.${environment().suffixes.storage}'

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/infra/core/apiManagement.bicep
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/infra/core/apiManagement.bicep
@@ -35,8 +35,8 @@ param exportFunctionBaseUrl string
 param contextStaticAppBaseUrl string
 
 
-@description('Instrumentation key for App Insights used with APIM')
-param appInsightsInstrumentationKey string
+@description('Connection String for App Insights used with APIM')
+param appInsightsConnectionString string
 
 @description('Core API Management Service Resources')
 module apimService 'apiManagement/service.bicep' = {
@@ -48,7 +48,7 @@ module apimService 'apiManagement/service.bicep' = {
     skuCount: skuCount
     publisherName: publisherName
     publisherEmail: publisherEmail
-    appInsightsInstrumentationKey: appInsightsInstrumentationKey
+    appInsightsConnectionString: appInsightsConnectionString
   }
 }
 

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/infra/core/apiManagement/service.bicep
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/infra/core/apiManagement/service.bicep
@@ -4,7 +4,7 @@ param sku string
 param skuCount int
 param publisherName string
 param publisherEmail string
-param appInsightsInstrumentationKey string
+param appInsightsConnectionString string
 
 resource apim 'Microsoft.ApiManagement/service@2021-12-01-preview' = {
   name: apiManagementServiceName
@@ -27,8 +27,7 @@ resource apim 'Microsoft.ApiManagement/service@2021-12-01-preview' = {
     properties: {
       loggerType: 'applicationInsights'
       credentials: {
-        appInsightsInstrumentationKey: appInsightsInstrumentationKey
-        instrumentationKey: appInsightsInstrumentationKey
+        connectionString: appInsightsConnectionString
       }
       isBuffered: true
     }

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/infra/core/monitoring.bicep
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/infra/core/monitoring.bicep
@@ -51,6 +51,5 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
   tags: appTags
 }
 
-output appInsightsInstrumentationKey string = appInsights.properties.InstrumentationKey
 output appInsightsConnectionString string = appInsights.properties.ConnectionString
 output appInsightsResourceId string = appInsights.id

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/infra/main.bicep
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/infra/main.bicep
@@ -162,7 +162,6 @@ module authCustomOperation './app/authCustomOperation.bicep' = {
     backendServiceVaultName: backendServiceVaultName
     contextAadApplicationId: ContextAppClientId
     appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
-    appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
     customOperationsFuncStorName: functionBase.outputs.storageAccountName
     hostingPlanId: functionBase.outputs.hostingPlanId
     redisCacheId: redis.outputs.redisCacheId
@@ -184,7 +183,6 @@ module exportCustomOperation './app/exportCustomOperation.bicep' = {
     apimName: apimName
     fhirUrl: fhirUrl
     appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
-    appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
     customOperationsFuncStorName: functionBase.outputs.storageAccountName
     hostingPlanId: functionBase.outputs.hostingPlanId
     enableVNetSupport: enableVNetSupport
@@ -241,7 +239,7 @@ module apim './core/apiManagement.bicep'= {
     smartAuthFunctionBaseUrl: 'https://${name}-aad-func.azurewebsites.net/api'
     exportFunctionBaseUrl: 'https://${name}-exp-func.azurewebsites.net/api'
     contextStaticAppBaseUrl: contextStaticWebApp.outputs.uri
-    appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+    appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
     enableVNetSupport: enableVNetSupport
   }
 }

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/src/SMARTCustomOperations.AzureAuth/Configuration/AzureAuthOperationsConfig.cs
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/src/SMARTCustomOperations.AzureAuth/Configuration/AzureAuthOperationsConfig.cs
@@ -38,8 +38,6 @@ namespace SMARTCustomOperations.AzureAuth.Configuration
 
         public string? AppInsightsConnectionString { get; set; }
 
-        public string? AppInsightsInstrumentationKey { get; set; }
-
         public string? TenantId { get; set; }
 
         public string? FhirAudience

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/src/SMARTCustomOperations.AzureAuth/Program.cs
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/src/SMARTCustomOperations.AzureAuth/Program.cs
@@ -49,11 +49,6 @@ namespace SMARTCustomOperations.AzureAuth
                         services.UseAppInsightsLogging(config.AppInsightsConnectionString, LogLevel.Information);
                         services.UseTelemetry(config.AppInsightsConnectionString);
                     }
-                    else if (config.AppInsightsInstrumentationKey is not null)
-                    {
-                        services.UseAppInsightsLogging(config.AppInsightsInstrumentationKey, LogLevel.Information);
-                        services.UseTelemetry(config.AppInsightsInstrumentationKey);
-                    }
                     // Add configuration
                     services.AddSingleton<AzureAuthOperationsConfig>(config);
 

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/src/SMARTCustomOperations.Export/Configuration/ExportCustomOperationsConfig.cs
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/src/SMARTCustomOperations.Export/Configuration/ExportCustomOperationsConfig.cs
@@ -14,8 +14,6 @@ namespace SMARTCustomOperations.Export.Configuration
 
         public string? AppInsightsConnectionString { get; set; }
 
-        public string? AppInsightsInstrumentationKey { get; set; }
-
         // Returns more detailed error messages to client
         public bool Debug { get; set; } = false;
 

--- a/samples/patientandpopulationservices-smartonfhir-oncg10/src/SMARTCustomOperations.Export/Program.cs
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/src/SMARTCustomOperations.Export/Program.cs
@@ -49,11 +49,6 @@ namespace SMARTCustomOperations.Export
                         services.UseAppInsightsLogging(config.AppInsightsConnectionString, LogLevel.Trace);
                         services.UseTelemetry(config.AppInsightsConnectionString);
                     }
-                    else if (config.AppInsightsInstrumentationKey is not null)
-                    {
-                        services.UseAppInsightsLogging(config.AppInsightsInstrumentationKey, LogLevel.Trace);
-                        services.UseTelemetry(config.AppInsightsInstrumentationKey);
-                    }
 
                     services.UseAzureFunctionPipeline();
 

--- a/samples/smartonfhir/infra/core/apiManagement.bicep
+++ b/samples/smartonfhir/infra/core/apiManagement.bicep
@@ -32,8 +32,8 @@ param smartAuthFunctionBaseUrl string
 param contextStaticAppBaseUrl string
 
 
-@description('Instrumentation key for App Insights used with APIM')
-param appInsightsInstrumentationKey string
+@description('Connection String for App Insights used with APIM')
+param appInsightsConnectionString string
 
 @description('Core API Management Service Resources')
 module apimService 'apiManagement/service.bicep' = {
@@ -45,7 +45,7 @@ module apimService 'apiManagement/service.bicep' = {
     skuCount: skuCount
     publisherName: publisherName
     publisherEmail: publisherEmail
-    appInsightsInstrumentationKey: appInsightsInstrumentationKey
+    appInsightsConnectionString: appInsightsConnectionString
   }
 }
 

--- a/samples/smartonfhir/infra/core/apiManagement/service.bicep
+++ b/samples/smartonfhir/infra/core/apiManagement/service.bicep
@@ -4,7 +4,7 @@ param sku string
 param skuCount int
 param publisherName string
 param publisherEmail string
-param appInsightsInstrumentationKey string
+param appInsightsConnectionString string
 
 resource apim 'Microsoft.ApiManagement/service@2021-12-01-preview' = {
   name: apiManagementServiceName
@@ -27,8 +27,7 @@ resource apim 'Microsoft.ApiManagement/service@2021-12-01-preview' = {
     properties: {
       loggerType: 'applicationInsights'
       credentials: {
-        appInsightsInstrumentationKey: appInsightsInstrumentationKey
-        instrumentationKey: appInsightsInstrumentationKey
+        connectionString: appInsightsConnectionString
       }
       isBuffered: true
     }

--- a/samples/smartonfhir/infra/core/monitoring.bicep
+++ b/samples/smartonfhir/infra/core/monitoring.bicep
@@ -51,6 +51,5 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
   tags: appTags
 }
 
-output appInsightsInstrumentationKey string = appInsights.properties.InstrumentationKey
 output appInsightsConnectionString string = appInsights.properties.ConnectionString
 output appInsightsResourceId string = appInsights.id

--- a/samples/smartonfhir/infra/main.bicep
+++ b/samples/smartonfhir/infra/main.bicep
@@ -157,7 +157,6 @@ module authCustomOperation './app/authCustomOperation.bicep' = {
     fhirServiceAudience: FhirAudience
     contextAadApplicationId: ContextAppClientId
     appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
-    appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
     customOperationsFuncStorName: functionBase.outputs.storageAccountName
     hostingPlanId: functionBase.outputs.hostingPlanId
     redisCacheId: redis.outputs.redisCacheId
@@ -205,7 +204,7 @@ module apim './core/apiManagement.bicep'= {
     fhirBaseUrl: fhirUrl
     smartAuthFunctionBaseUrl: 'https://${name}-aad-func.azurewebsites.net/api'
     contextStaticAppBaseUrl: contextStaticWebApp.outputs.uri
-    appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+    appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
     enableVNetSupport: enableVNetSupport
   }
 }

--- a/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth/Configuration/AzureAuthOperationsConfig.cs
+++ b/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth/Configuration/AzureAuthOperationsConfig.cs
@@ -38,8 +38,6 @@ namespace SMARTCustomOperations.AzureAuth.Configuration
 
         public string? AppInsightsConnectionString { get; set; }
 
-        public string? AppInsightsInstrumentationKey { get; set; }
-
         public string? TenantId { get; set; }
 
         public string? FhirAudience

--- a/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth/Program.cs
+++ b/samples/smartonfhir/src/SMARTCustomOperations.AzureAuth/Program.cs
@@ -48,12 +48,7 @@ namespace SMARTCustomOperations.AzureAuth
                     {
                         services.UseAppInsightsLogging(config.AppInsightsConnectionString, LogLevel.Information);
                         services.UseTelemetry(config.AppInsightsConnectionString);
-                    }
-                    else if (config.AppInsightsInstrumentationKey is not null)
-                    {
-                        services.UseAppInsightsLogging(config.AppInsightsInstrumentationKey, LogLevel.Information);
-                        services.UseTelemetry(config.AppInsightsInstrumentationKey);
-                    }
+                    }                   
                     // Add configuration
                     services.AddSingleton<AzureAuthOperationsConfig>(config);
 

--- a/samples/smartonfhir/src/SMARTCustomOperations.Export/Configuration/ExportCustomOperationsConfig.cs
+++ b/samples/smartonfhir/src/SMARTCustomOperations.Export/Configuration/ExportCustomOperationsConfig.cs
@@ -14,8 +14,6 @@ namespace SMARTCustomOperations.Export.Configuration
 
         public string? AppInsightsConnectionString { get; set; }
 
-        public string? AppInsightsInstrumentationKey { get; set; }
-
         // Returns more detailed error messages to client
         public bool Debug { get; set; } = false;
 

--- a/samples/smartonfhir/src/SMARTCustomOperations.Export/Program.cs
+++ b/samples/smartonfhir/src/SMARTCustomOperations.Export/Program.cs
@@ -49,11 +49,6 @@ namespace SMARTCustomOperations.Export
                         services.UseAppInsightsLogging(config.AppInsightsConnectionString, LogLevel.Trace);
                         services.UseTelemetry(config.AppInsightsConnectionString);
                     }
-                    else if (config.AppInsightsInstrumentationKey is not null)
-                    {
-                        services.UseAppInsightsLogging(config.AppInsightsInstrumentationKey, LogLevel.Trace);
-                        services.UseTelemetry(config.AppInsightsInstrumentationKey);
-                    }
 
                     services.UseAzureFunctionPipeline();
 


### PR DESCRIPTION
Implemented changes in Smart on FHIR and PatientandPopulation-oncg10 samples for handling app insights logging using connection string instead of instrumentation key
Transition to using connection strings for data ingestion

User story- https://microsofthealth.visualstudio.com/Health/_workitems/edit/148419