### PR TITLE
Fix SMART on FHIR Deployment Issue with Latest AZD Version

### DIFF
--- a/samples/patientandpopulationservices-smartonfhir-oncg10/infra/main.bicep
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10/infra/main.bicep
@@ -45,6 +45,10 @@ param fhirId string
 @description('Name of the Log Analytics workspace to deploy or use. Leave blank to skip deployment')
 param logAnalyticsName string = ''
 
+@allowed([
+  true
+  false
+])
 @description('Deploy sample with Virtual Network')
 param enableVNetSupport bool
 

--- a/samples/smartonfhir/infra/app/authCustomOperation.bicep
+++ b/samples/smartonfhir/infra/app/authCustomOperation.bicep
@@ -37,9 +37,6 @@ param fhirServiceAudience string
 @description('Microsoft Entra ID Application ID for the context application.')
 param contextAadApplicationId string
 
-@description('App Insights Instrumentation Key for the sample. (Optional)')
-param appInsightsInstrumentationKey string
-
 @description('App Insights Connection String for the sample. (Optional)')
 param appInsightsConnectionString string
 
@@ -120,13 +117,11 @@ resource authCustomOperationAppSettings 'Microsoft.Web/sites/config@2020-12-01' 
     // WEBSITE_CONTENTSHARE: authCustomOperationsFunctionAppName
     FUNCTIONS_EXTENSION_VERSION: '~4'
     FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-    APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
     SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
     ENABLE_ORYX_BUILD: 'true'
 
     AZURE_ApiManagementHostName: '${apimName}.azure-api.net'
-    AZURE_APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
     AZURE_APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
     AZURE_TenantId: tenantId
     AZURE_SmartonFhir_with_B2C: '${smartOnFhirWithB2C}'

--- a/samples/smartonfhir/infra/main.bicep
+++ b/samples/smartonfhir/infra/main.bicep
@@ -45,6 +45,10 @@ param fhirId string
 @description('Name of the Log Analytics workspace to deploy or use. Leave blank to skip deployment')
 param logAnalyticsName string = ''
 
+@allowed([
+  true
+  false
+])
 @description('Deploy sample with Virtual Network')
 param enableVNetSupport bool
 


### PR DESCRIPTION
Deployment of the SMART on FHIR sample fails with the latest Azure Developer CLI due to stricter parameter type enforcement. Update the Bicep/infra code to align with the new requirements and ensure successful deployment.