### PR TITLE
Add minimal SMART-aware shim proof for backend services

### DIFF
--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/INVESTIGATION_RESULTS.md
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/INVESTIGATION_RESULTS.md
@@ -1,0 +1,255 @@
+# SMART backend auth investigation results
+
+## Summary
+
+This investigation tested whether SMART on FHIR asymmetric client authentication for Inferno and backend-services clients could work directly with Microsoft Entra, without the current Azure Function + Key Vault exchange pattern.
+
+### Bottom line
+
+- **Manual public-key registration is allowed by the SMART spec.**
+- **Microsoft Entra can store manually registered public-key material if it is uploaded as an X.509 certificate.**
+- **However, Entra did not accept Inferno's actual client assertion after uploading a certificate derived from Inferno's RSA JWKS key.**
+- This is strong evidence that **JWKS-only registration does not map cleanly to Entra's certificate-based client assertion validation model**.
+
+## Questions investigated
+
+1. Can a direct backend-services flow work against **standard Entra** or **Entra External** without the current token-exchange bridge?
+2. Can Inferno's registration model (`jwks_uri`, `RS384` / `ES384`) be represented in Entra?
+3. If SMART allows **manual registration** of a client's public key, can that manual step be implemented by uploading equivalent key material to Entra?
+
+## SMART spec findings
+
+From the SMART App Launch STU2 `client-confidential-asymmetric` profile:
+
+- SMART does **not** require a specific registration protocol.
+- A client may register its public key with the authorization server by:
+  1. **JWKS URL** (preferred), or
+  2. **JWKS directly** at registration time.
+- The auth server is expected to validate `private_key_jwt` using:
+  - `kid`
+  - optionally `jku`
+  - the registration-time JWKS URL or JWKS value
+- The profile requires support for asymmetric signatures including **`RS384`** or **`ES384`**.
+
+Conclusion from the spec:
+
+- **A manual registration step is absolutely allowed.**
+- The real question is **whether the target authorization server actually implements SMART's JWKS-based validation behavior** after registration.
+
+## Entra behavior investigated
+
+### Observed Entra model
+
+For app authentication, Microsoft Entra expects:
+
+- client key material to be pre-registered on the app registration,
+- commonly as an uploaded **X.509 certificate** (`keyCredentials`),
+- and then uses that registered certificate identity to validate the client assertion.
+
+Observed/confirmed constraints:
+
+- Entra does **not** natively dereference a client-controlled **`jku` / JWKS URI** at token time.
+- Entra's documented certificate-credential flow differs from SMART's asymmetric client profile.
+- A matching **public key in raw JWKS form** is not treated as equivalent to a pre-registered Entra certificate identity.
+
+## Experiments run
+
+## 1. Proof kit creation
+
+A proof kit was added under:
+
+`samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/`
+
+Artifacts added:
+
+- `Test-BackendDirectAuth.ps1`
+- `direct-backend-auth.http`
+- `direct-backend-auth-entra.http`
+- `Prepare-InfernoJwksUploadArtifacts.py`
+
+Purpose:
+
+- test direct backend token acquisition against standard Entra and Entra External,
+- inspect resulting token claims,
+- test direct FHIR access,
+- and experiment with uploading Inferno-derived key material into Entra.
+
+## 2. Inferno JWKS inspection
+
+Inferno's SMART STU2 JWKS contains:
+
+- one **EC / ES384** key
+- one **RSA / RS384** key
+
+The RSA key used for the upload experiment had:
+
+- `kid`: `b41528b6f37a9500edb8a905a595bdd7`
+- `alg`: `RS384`
+
+## 3. JWKS-to-certificate conversion
+
+We converted Inferno's **RSA JWK** (`n`, `e`) into:
+
+- a PEM public key
+- an X.509 certificate wrapping that public key
+- a `.cer` artifact suitable for Entra upload
+
+This proves that **Inferno's bare RSA public key can be transformed into an uploadable Entra artifact**.
+
+## 4. Entra app registration upload test
+
+Target tenant:
+
+- `837cfeb2-55a3-4d9e-a40f-f822b4cd2391`
+
+Target app registration:
+
+- app/client ID: `d5fdde5d-5825-4276-840f-cd34d5966dd7`
+- display name: `mikaelw-backend-test1`
+
+Upload result:
+
+- upload command succeeded
+- Entra app object showed **1 keyCredential**
+- uploaded key credential:
+  - `displayName`: `CN=Inferno JWKS Upload Test`
+  - `type`: `AsymmetricX509Cert`
+  - `usage`: `Verify`
+  - `customKeyIdentifier`: `EC6AF63255C3551E6EC6DEE6B75292C3B560AA89`
+
+Conclusion:
+
+- **Entra accepted the uploaded certificate artifact**
+- so **manual registration into Entra is operationally possible**
+
+## 5. Inferno runtime test against Entra
+
+After uploading the Inferno-derived certificate, Inferno was run against Entra and the token request failed with:
+
+```json
+{
+  "error": "invalid_client",
+  "error_description": "AADSTS700027: The certificate with identifier used to sign the client assertion is not registered on application. [Reason - The key was not found.]"
+}
+```
+
+Meaning:
+
+- Entra did **not** accept the assertion as signed by a registered certificate
+- even though the app had a certificate containing the same RSA public key material
+
+## Interpretation of the failure
+
+This failure strongly suggests that Entra is **not** validating Inferno's assertion as:
+
+> "the signature verifies under a registered equivalent public key"
+
+Instead, Entra appears to require something closer to:
+
+> "the assertion references a specific certificate identity that matches registered Entra key credentials"
+
+Why the wrapper-cert approach failed:
+
+- Inferno publishes a **JWKS**
+- Inferno does **not** publish the exact X.509 cert identity Entra expects
+- we created a **new** certificate around the same public key
+- that new certificate has a **different certificate identity / thumbprint**
+- Entra still rejected the assertion
+
+## What this proves
+
+### Proven
+
+- SMART allows manual client public-key registration.
+- Entra can store manually uploaded certificate-based public-key material.
+- A JWKS RSA public key can be transformed into an Entra-uploadable cert artifact.
+- Uploading a cert derived from Inferno's RSA JWKS is **not sufficient** for Entra to accept Inferno's actual assertion.
+
+### Not proven
+
+- That standard Entra can satisfy Inferno's exact asymmetric client-authentication requirements
+- That Entra External can satisfy Inferno's exact asymmetric client-authentication requirements
+- That Entra can function as a native SMART `client-confidential-asymmetric` authorization server for `jwks_uri` / `jku`-based client registration
+
+## Current conclusion
+
+At this point, the evidence supports the following conclusion:
+
+> **Manual registration alone is not the blocker.**
+>
+> The blocker is that **SMART JWKS-based client trust** and **Entra's certificate-based client assertion validation** are not equivalent models.
+
+So while Entra can accept manually uploaded cert material, that does **not** make it a drop-in implementation of SMART asymmetric client authentication as used by Inferno.
+
+## What would be needed for further testing
+
+One of the following would be needed to continue the experiment meaningfully:
+
+1. **Inferno's actual certificate material**
+   - so the exact cert identity used in the assertion could be registered in Entra
+2. **A backend client we control**
+   - where we control the private key and can generate an Entra-compatible assertion format
+3. **A SMART-aware auth layer**
+   - that validates `jwks_uri` / JWKS directly instead of relying on Entra to do that validation
+
+## Recommended next step
+
+If the goal is to support Inferno `(g)(10)` asymmetric client authentication exactly as specified, the safest conclusion from this investigation is:
+
+- **Do not assume Entra alone can replace a SMART-aware asymmetric client validator.**
+
+If the goal is instead to prove direct backend auth for a **vendor-controlled client**, continue with the proof kit using:
+
+- a backend app registration you control,
+- a certificate you control,
+- a client assertion generated in the format Entra expects,
+- and then test direct FHIR access separately from Inferno.
+
+## Entra External ID addendum
+
+We also considered whether **Microsoft Entra External ID** changes the conclusion.
+
+### What Entra External ID likely helps with
+
+- Azure FHIR can trust Entra External ID as an **external OIDC identity provider**
+- Entra External supports **machine-to-machine** patterns for app-only access
+- Entra External also supports **federated credentials** for token exchange from trusted external issuers
+
+### What Entra External ID likely does not change
+
+The main mismatch for Inferno appears to remain the same:
+
+- Inferno uses the SMART asymmetric client model:
+  - registration by `jwks_uri` / JWKS
+  - `private_key_jwt`
+  - `RS384` / `ES384`
+- Entra External still uses Microsoft identity platform authentication patterns:
+  - pre-registered cert/key material
+  - Entra-style client assertion validation, or
+  - federated credential token exchange
+
+This means the likely weak point is still:
+
+> **Inferno -> Entra External**
+
+not:
+
+> **Entra External -> FHIR**
+
+### Current conclusion on Entra External
+
+At this stage, Entra External should be viewed as:
+
+- **likely viable on the FHIR trust side**, but
+- **not yet shown to solve Inferno's native SMART asymmetric client-auth flow**
+
+In other words:
+
+> Entra External may help FHIR trust an external issuer, but it does not appear to add a SMART-native `jwks_uri` / `jku` / `RS384`-style client authentication model that would make Inferno work unchanged.
+
+### Practical takeaway
+
+If the goal is:
+
+- **vendor-controlled backend auth** -> Entra External may still be worth testing with Entra-compatible cert auth or federated credentials
+- **Inferno exact asymmetric SMART client auth** -> Entra External is still likely restricted in the same core way as standard Entra, unless a SMART-aware shim is introduced

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/Prepare-InfernoJwksUploadArtifacts.py
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/Prepare-InfernoJwksUploadArtifacts.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import json
+import sys
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+
+DEFAULT_JWKS_URL = "https://inferno.healthit.gov/suites/custom/smart_stu2/.well-known/jwks.json"
+
+
+def b64url_to_int(value: str) -> int:
+    padding = "=" * ((4 - len(value) % 4) % 4)
+    data = base64.urlsafe_b64decode(value + padding)
+    return int.from_bytes(data, "big")
+
+
+def der_len(length: int) -> bytes:
+    if length < 0x80:
+        return bytes([length])
+
+    encoded = []
+    while length:
+        encoded.append(length & 0xFF)
+        length >>= 8
+    encoded.reverse()
+    return bytes([0x80 | len(encoded)]) + bytes(encoded)
+
+
+def der_integer(value: int) -> bytes:
+    if value == 0:
+        body = b"\x00"
+    else:
+        body = value.to_bytes((value.bit_length() + 7) // 8, "big")
+        if body[0] & 0x80:
+            body = b"\x00" + body
+    return b"\x02" + der_len(len(body)) + body
+
+
+def der_sequence(parts: List[bytes]) -> bytes:
+    body = b"".join(parts)
+    return b"\x30" + der_len(len(body)) + body
+
+
+def der_bit_string(body: bytes) -> bytes:
+    prefixed = b"\x00" + body
+    return b"\x03" + der_len(len(prefixed)) + prefixed
+
+
+def build_subject_public_key_info(n_value: int, e_value: int) -> bytes:
+    rsa_public_key = der_sequence([der_integer(n_value), der_integer(e_value)])
+    algorithm_identifier = bytes.fromhex("300d06092a864886f70d0101010500")
+    return der_sequence([algorithm_identifier, der_bit_string(rsa_public_key)])
+
+
+def pem_wrap(label: str, der_bytes: bytes) -> str:
+    encoded = base64.encodebytes(der_bytes).decode("ascii").replace("\n", "")
+    lines = [encoded[i:i + 64] for i in range(0, len(encoded), 64)]
+    return f"-----BEGIN {label}-----\n" + "\n".join(lines) + f"\n-----END {label}-----\n"
+
+
+def fetch_jwks(url: str) -> dict:
+    with urllib.request.urlopen(url) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def select_rsa_key(jwks: dict, kid: Optional[str]) -> dict:
+    keys = jwks.get("keys", [])
+    rsa_keys = [key for key in keys if key.get("kty") == "RSA"]
+    if not rsa_keys:
+        raise ValueError("No RSA keys found in the JWKS.")
+
+    if kid:
+        for key in rsa_keys:
+            if key.get("kid") == kid:
+                return key
+        raise ValueError(f"No RSA key with kid '{kid}' found in the JWKS.")
+
+    return rsa_keys[0]
+
+
+def write_text(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def write_json(path: Path, content: object) -> None:
+    path.write_text(json.dumps(content, indent=2), encoding="utf-8")
+
+
+def build_published_jwks(source_jwks: dict, selected_key: dict, mode: str) -> dict:
+    if mode == "selected-rsa":
+        return {"keys": [selected_key]}
+
+    if mode == "full-source":
+        return source_jwks
+
+    raise ValueError(f"Unsupported OIDC JWKS mode '{mode}'.")
+
+
+def collect_signing_algs(jwks: dict) -> List[str]:
+    algs = sorted({key.get("alg") for key in jwks.get("keys", []) if key.get("alg")})
+    return [alg for alg in algs if alg]
+
+
+def normalize_url(url: str) -> str:
+    return url.rstrip("/")
+
+
+def write_oidc_package(
+    output_dir: Path,
+    issuer_url: str,
+    source_jwks: dict,
+    selected_key: dict,
+    jwks_mode: str,
+    federated_audience: str,
+    federated_subject: Optional[str],
+) -> Path:
+    issuer = normalize_url(issuer_url)
+    oidc_dir = output_dir / "inferno-oidc-issuer"
+    well_known_dir = oidc_dir / ".well-known"
+    well_known_dir.mkdir(parents=True, exist_ok=True)
+
+    published_jwks = build_published_jwks(source_jwks, selected_key, jwks_mode)
+    signing_algs = collect_signing_algs(published_jwks)
+
+    openid_configuration = {
+        "issuer": issuer,
+        "jwks_uri": f"{issuer}/jwks.json",
+        "response_types_supported": ["id_token"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": signing_algs,
+    }
+
+    sample_federated_credential = {
+        "name": "inferno-custom-oidc-trust",
+        "issuer": issuer,
+        "subject": federated_subject or "__SET_INFERNO_TOKEN_SUBJECT__",
+        "audiences": [federated_audience],
+        "description": "Sample federated credential payload for testing a custom OIDC trust using Inferno JWKS.",
+    }
+
+    write_json(well_known_dir / "openid-configuration", openid_configuration)
+    write_json(well_known_dir / "openid-configuration.json", openid_configuration)
+    write_json(oidc_dir / "jwks.json", published_jwks)
+    write_json(oidc_dir / "source-jwks.json", source_jwks)
+    write_json(oidc_dir / "federated-credential-sample.json", sample_federated_credential)
+    write_text(
+        oidc_dir / "README.txt",
+        "\n".join(
+            [
+                "Inferno custom OIDC trust issuer package",
+                "",
+                f"Issuer URL: {issuer}",
+                f"JWKS mode: {jwks_mode}",
+                f"Published algorithms: {', '.join(signing_algs) if signing_algs else '(none declared)'}",
+                "",
+                "Files:",
+                "- .well-known/openid-configuration: OIDC discovery document",
+                "- jwks.json: Published JWKS for the custom issuer",
+                "- source-jwks.json: Original fetched Inferno JWKS",
+                "- federated-credential-sample.json: Sample trust payload for Microsoft Entra workload federation tests",
+                "",
+                "Important:",
+                "- Host these files at a public HTTPS URL whose base exactly matches the issuer value.",
+                "- This package proves OIDC discovery + JWKS hosting mechanics only.",
+                "- It does NOT by itself make Inferno assertions valid for workload identity federation.",
+                "- The incoming external token still needs issuer/subject/audience claims that match the federated credential definition.",
+                "- Inferno SMART client assertions typically use SMART-specific iss/sub/aud values, so a claim-shape mismatch remains likely.",
+            ]
+        ),
+    )
+
+    return oidc_dir
+
+
+def parse_subject(subject: str) -> x509.Name:
+    values = []
+    for part in subject.split("/"):
+        if not part:
+            continue
+        key, value = part.split("=", 1)
+        if key == "CN":
+            values.append(x509.NameAttribute(NameOID.COMMON_NAME, value))
+        else:
+            raise ValueError(f"Unsupported subject attribute '{key}'. Only CN is supported.")
+    if not values:
+        raise ValueError("Subject must include at least /CN=<value>.")
+    return x509.Name(values)
+
+
+def generate_certificate(n_value: int, e_value: int, cert_pem: Path, cert_der: Path, signer_key: Path, subject: str, days: int) -> None:
+    inferno_public_key = rsa.RSAPublicNumbers(e_value, n_value).public_key()
+    signer_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+    subject_name = parse_subject(subject)
+    issuer_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Local Inferno JWKS Upload Test Issuer")])
+
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject_name)
+        .issuer_name(issuer_name)
+        .public_key(inferno_public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=days))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(inferno_public_key), critical=False)
+        .sign(private_key=signer_private_key, algorithm=hashes.SHA256())
+    )
+
+    cert_pem.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    cert_der.write_bytes(certificate.public_bytes(serialization.Encoding.DER))
+    signer_key.write_bytes(
+        signer_private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+
+
+def maybe_upload_certificate(app_id: str, cert_path: Path) -> None:
+    import subprocess
+
+    process = subprocess.run(
+        [
+            "az",
+            "ad",
+            "app",
+            "credential",
+            "reset",
+            "--id",
+            app_id,
+            "--cert",
+            f"@{cert_path}",
+            "--append",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"Azure CLI upload failed.\nSTDOUT:\n{process.stdout}\nSTDERR:\n{process.stderr}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch Inferno JWKS, convert the RSA key to PEM/X.509 artifacts, and optionally emit a minimal OIDC issuer package or upload the public cert to Entra."
+    )
+    parser.add_argument("--jwks-url", default=DEFAULT_JWKS_URL, help="JWKS URL to fetch")
+    parser.add_argument("--kid", help="Specific RSA kid to use from the JWKS")
+    parser.add_argument("--output-dir", default="inferno-jwks-artifacts", help="Directory to write generated artifacts")
+    parser.add_argument("--subject", default="/CN=Inferno JWKS Upload Test", help="Subject for the generated X.509 certificate")
+    parser.add_argument("--days", type=int, default=365, help="Number of days for the generated certificate")
+    parser.add_argument("--oidc-issuer-url", help="If provided, create a minimal static OIDC issuer package for the fetched Inferno JWKS.")
+    parser.add_argument(
+        "--oidc-jwks-mode",
+        choices=["selected-rsa", "full-source"],
+        default="selected-rsa",
+        help="JWKS content to publish in the generated OIDC issuer package.",
+    )
+    parser.add_argument(
+        "--federated-audience",
+        default="api://AzureADTokenExchange",
+        help="Audience value to place in the sample federated credential JSON.",
+    )
+    parser.add_argument("--federated-subject", help="Optional subject value to place in the sample federated credential JSON.")
+    parser.add_argument("--app-id", help="Entra app registration appId/clientId for optional upload")
+    parser.add_argument("--upload", action="store_true", help="Upload the generated public certificate to the Entra app registration")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    jwks = fetch_jwks(args.jwks_url)
+    selected_key = select_rsa_key(jwks, args.kid)
+
+    n_value = b64url_to_int(selected_key["n"])
+    e_value = b64url_to_int(selected_key["e"])
+    spki_der = build_subject_public_key_info(n_value, e_value)
+    public_key_pem = pem_wrap("PUBLIC KEY", spki_der)
+
+    public_key_path = output_dir / "inferno-rsa-public-key.pem"
+    selected_key_path = output_dir / "selected-inferno-rsa-jwk.json"
+    cert_pem_path = output_dir / "inferno-rsa-upload-cert.pem"
+    cert_der_path = output_dir / "inferno-rsa-upload-cert.cer"
+    signer_key_path = output_dir / "local-signer-private-key.pem"
+    notes_path = output_dir / "README.txt"
+
+    write_text(public_key_path, public_key_pem)
+    write_json(selected_key_path, selected_key)
+    generate_certificate(n_value, e_value, cert_pem_path, cert_der_path, signer_key_path, args.subject, args.days)
+
+    write_text(
+        notes_path,
+        "\n".join(
+            [
+                "Inferno JWKS upload experiment artifacts",
+                "",
+                f"JWKS source: {args.jwks_url}",
+                f"Selected kid: {selected_key.get('kid')}",
+                f"Selected alg: {selected_key.get('alg')}",
+                "",
+                "Files:",
+                f"- {public_key_path.name}: SubjectPublicKeyInfo PEM generated from the RSA JWK",
+                f"- {cert_pem_path.name}: X.509 PEM wrapping the Inferno RSA public key",
+                f"- {cert_der_path.name}: DER/cer form of the same certificate for Entra upload tests",
+                f"- {signer_key_path.name}: Local signer key used only to create the wrapper certificate",
+                "",
+                "Important:",
+                "- This proves public-key registration mechanics only.",
+                "- It does not prove that Entra will accept Inferno's full SMART-style client assertion format or RS384 semantics.",
+            ]
+        ),
+    )
+
+    oidc_package_path = None
+    if args.oidc_issuer_url:
+        oidc_package_path = write_oidc_package(
+            output_dir=output_dir,
+            issuer_url=args.oidc_issuer_url,
+            source_jwks=jwks,
+            selected_key=selected_key,
+            jwks_mode=args.oidc_jwks_mode,
+            federated_audience=args.federated_audience,
+            federated_subject=args.federated_subject,
+        )
+
+    if args.upload:
+        if not args.app_id:
+            raise ValueError("--app-id is required when --upload is used.")
+        maybe_upload_certificate(args.app_id, cert_der_path)
+
+    print(json.dumps(
+        {
+            "outputDir": str(output_dir),
+            "selectedKid": selected_key.get("kid"),
+            "selectedAlg": selected_key.get("alg"),
+            "publicKeyPem": str(public_key_path),
+            "uploadCertPem": str(cert_pem_path),
+            "uploadCertCer": str(cert_der_path),
+            "oidcIssuerPackage": str(oidc_package_path) if oidc_package_path else None,
+            "uploaded": bool(args.upload),
+        },
+        indent=2,
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1)

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/README.md
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/README.md
@@ -1,0 +1,328 @@
+# Direct backend auth proof kit
+
+This folder is a **manual proof kit** for testing whether SMART on FHIR backend-services auth can work with either:
+
+- **Microsoft Entra External**, or
+- a standard **Microsoft Entra tenant**
+
+without the current Azure Function + Key Vault exchange pattern.
+
+It does **not** modify the existing `(g)(10)` SMART implementation. It gives you a repeatable way to:
+
+1. request a backend token directly from the identity provider,
+2. inspect the resulting JWT claims, and
+3. call the FHIR service directly with that token.
+
+## Repo assets this proof reuses
+
+- `samples/fhir-aad-entra-external/` for the Entra External + FHIR trust direction
+- `samples/client-assertion-generator/` if you want to generate a `client_assertion` and JWKS from a certificate
+
+## Prerequisites
+
+Before running the proof, you need:
+
+1. A FHIR service configured to trust the authority you want to test.
+   - For **Entra External**, this usually means `authenticationConfiguration.smartIdentityProviders`.
+   - For a standard **Entra tenant**, this can be the primary authority already used by the FHIR service, or another trusted configuration if you are testing a separate authority.
+2. A backend client registration in the identity provider being tested.
+3. A token endpoint URL for that tenant.
+4. The FHIR audience or scope expected by the resource app.
+5. A `client_assertion` for the backend client if you are validating a SMART-style `private_key_jwt` request.
+
+## Option A: run the PowerShell proof script
+
+The script requests a token, decodes the access token, highlights risky claims, and optionally performs a direct FHIR read.
+
+```powershell
+pwsh ./Test-BackendDirectAuth.ps1 `
+  -TokenEndpoint "https://<your-tenant>.ciamlogin.com/<your-tenant-id>/oauth2/v2.0/token" `
+  -ClientId "<backend-client-id>" `
+  -FhirAudience "api://<your-fhir-resource-app-id>" `
+  -ClientAssertionFile "./client-assertion.txt" `
+  -FhirBaseUrl "https://<your-fhir-service>.fhir.azurehealthcareapis.com" `
+  -OutputDirectory "./artifacts"
+```
+
+### Useful parameters
+
+- `-Scope` if you want to provide the exact scope instead of deriving `/.default` from `-FhirAudience`
+- `-ClientAssertion` if you want to paste the assertion inline instead of loading it from a file
+- `-FhirRelativePath` if you want to test a different read path than `Patient?_count=1`
+
+### Script outputs
+
+If `-OutputDirectory` is provided, the script writes:
+
+- `token-response.json`
+- `access-token-header.json`
+- `access-token-claims.json`
+- `proof-summary.json`
+- `fhir-result.json` when a FHIR request is attempted
+
+The same script also works for a standard Entra tenant by swapping the token endpoint:
+
+```powershell
+pwsh ./Test-BackendDirectAuth.ps1 `
+  -TokenEndpoint "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token" `
+  -ClientId "<backend-client-id>" `
+  -FhirAudience "api://<your-fhir-resource-app-id>" `
+  -ClientAssertionFile "./client-assertion.txt" `
+  -FhirBaseUrl "https://<your-fhir-service>.fhir.azurehealthcareapis.com" `
+  -OutputDirectory "./artifacts-entra"
+```
+
+## Option C: run the minimal SMART-aware shim proof
+
+If you want to test the recommended direct-trust architecture instead of the current Entra secret-exchange bridge, use:
+
+```bash
+python3 ./Run-MinimalSmartShim.py \
+  --issuer "http://127.0.0.1:8765"
+```
+
+The shim serves:
+
+- `/.well-known/openid-configuration`
+- `/jwks.json`
+- `POST /token`
+
+### What the shim proof does
+
+- loads backend-client registrations from `./registrations/*.json`
+- validates SMART `private_key_jwt` assertions for `client_credentials`
+- supports inbound `RS384` and `ES384`
+- enforces:
+  - `iss = sub = client_id`
+  - `aud = <shim issuer>/token`
+  - `kid` matching
+  - `jku` = registered `jwksUri` when present
+  - one-time-use `jti`
+- issues a shim-signed access token that can be used for Azure FHIR direct-trust experiments
+
+### Registration format
+
+Use `registrations/inferno-client.template.json` as the template for a backend client registration.
+
+Important fields:
+
+- `clientId`: exact SMART `client_id` / `iss` / `sub` value expected from the client assertion
+- `jwksUri`: client public JWKS endpoint
+- `allowedScopes`: scopes the shim will allow for that client
+- `fhirAudience`: audience claim to emit in the shim-issued token
+- `fhirUser`: optional proof claim to emit for Azure FHIR trust experiments
+
+### Running a local token request
+
+Once the shim is running and a client registration is in place:
+
+```bash
+curl -X POST "http://127.0.0.1:8765/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" \
+  --data-urlencode "client_assertion=$(cat ./client-assertion.txt)" \
+  --data-urlencode "scope=system/*.r"
+```
+
+### Important proof limitations
+
+- this is a **proof shim**, not a production authorization server
+- replay protection is local to the proof service state file
+- the issued token claim shape still needs to be validated against your Azure FHIR configuration
+- the shim signs its **outbound** tokens with its own key; inbound client assertions remain SMART `RS384` / `ES384`
+
+### Azure FHIR direct-trust example
+
+For a direct-trust proof, Azure FHIR needs to trust the shim authority and allowlist the backend client IDs that the shim emits in `azp` / `appid`.
+
+Example shape:
+
+```json
+{
+  "properties": {
+    "authenticationConfiguration": {
+      "authority": "https://login.microsoftonline.com/<primary-tenant-id>",
+      "audience": "https://<your-fhir-service>.fhir.azurehealthcareapis.com",
+      "smartProxyEnabled": false,
+      "smartIdentityProviders": [
+        {
+          "authority": "https://<your-shim-host>",
+          "applications": [
+            {
+              "clientId": "<registered-backend-client-id>",
+              "audience": "api://<your-fhir-resource-app-id>",
+              "allowedDataActions": ["Read"]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+For this proof, the important claim mapping is:
+
+- shim token `iss` -> shim `authority`
+- shim token `aud` -> `applications[].audience`
+- shim token `azp` or `appid` -> `applications[].clientId`
+- shim token `scp` -> SMART/backend scope
+- shim token `fhirUser` -> optional proof claim to satisfy Azure FHIR identity-provider expectations
+
+## Option B: run the REST Client files
+
+Open one of these files in VS Code with the REST Client extension, fill in the placeholders, send the token request, then send the FHIR request:
+
+- `direct-backend-auth.http` for **Entra External**
+- `direct-backend-auth-entra.http` for a standard **Entra tenant**
+
+This is useful when you want a quick manual run before using the script.
+
+## Inferno RSA JWKS upload experiment
+
+If you want to test whether Entra can trust Inferno's RSA public key once it is wrapped in an uploadable certificate, use:
+
+```bash
+python3 ./Prepare-InfernoJwksUploadArtifacts.py --output-dir ./inferno-jwks-artifacts
+```
+
+This script:
+
+1. fetches Inferno's JWKS,
+2. selects the RSA key,
+3. converts that JWK into a PEM public key,
+4. wraps the public key in an X.509 certificate, and
+5. writes both PEM and `.cer` artifacts for upload tests.
+
+To upload the generated cert to an Entra app registration:
+
+```bash
+python3 ./Prepare-InfernoJwksUploadArtifacts.py \
+  --output-dir ./inferno-jwks-artifacts \
+  --app-id "<backend-client-id>" \
+  --upload
+```
+
+Equivalent Azure CLI upload command:
+
+```bash
+az ad app credential reset \
+  --id "<backend-client-id>" \
+  --cert "@./inferno-jwks-artifacts/inferno-rsa-upload-cert.cer" \
+  --append
+```
+
+Important:
+
+- this tests whether Entra will accept **registered public key material** derived from Inferno's RSA JWK,
+- it does **not** prove that Entra will accept Inferno's full SMART-style assertion format,
+- and it does **not** make Entra a native `jku`/JWKS-dereferencing authorization server.
+
+## Minimal custom OIDC trust issuer experiment
+
+If you want a very small experiment that publishes Inferno's JWKS through a custom OIDC discovery document for trust testing, use:
+
+```bash
+python3 ./Prepare-InfernoJwksUploadArtifacts.py \
+  --output-dir ./inferno-jwks-artifacts \
+  --oidc-issuer-url "https://<your-public-host>/inferno-oidc-test"
+```
+
+This writes a static package under:
+
+- `inferno-jwks-artifacts/inferno-oidc-issuer/.well-known/openid-configuration`
+- `inferno-jwks-artifacts/inferno-oidc-issuer/jwks.json`
+- `inferno-jwks-artifacts/inferno-oidc-issuer/federated-credential-sample.json`
+
+Useful options:
+
+- `--oidc-jwks-mode selected-rsa` to publish only the selected Inferno RSA key (default)
+- `--oidc-jwks-mode full-source` to publish the full fetched Inferno JWKS
+- `--federated-subject "<expected-sub-claim>"` to prefill the sample federated credential JSON
+- `--federated-audience "<audience>"` to override the default `api://AzureADTokenExchange`
+
+This experiment is intended to answer a narrower question:
+
+> Can Microsoft Entra resolve a custom OIDC issuer and its hosted JWKS when that issuer publishes Inferno-derived key material?
+
+Important:
+
+- this package is **static OIDC discovery + JWKS hosting only**
+- it does **not** generate tokens
+- it does **not** make Inferno's SMART `client_assertion` automatically compatible with workload identity federation
+- the external token still needs `iss`, `sub`, and `aud` values that exactly match the federated credential definition
+- Inferno SMART assertions usually use SMART-specific claim values, so a claim-shape mismatch may still block the exchange even if Entra can read the JWKS
+
+## Parallel experiment: standard Entra tenant
+
+Use the standard Entra experiment when you want to answer a narrower question:
+
+> If the backend client is registered directly in a normal Entra tenant, and authenticates with `private_key_jwt` or a certificate-backed client assertion, can it get a token that works directly against FHIR?
+
+Suggested setup for that parallel test:
+
+1. Register the FHIR resource application in the Entra tenant.
+2. Register a backend confidential client in the same tenant.
+3. Upload the backend certificate/public key to that client registration.
+4. Grant the backend client the FHIR application permission you want to test.
+5. Request a token from `https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`.
+6. Compare the resulting token claims and FHIR behavior against the Entra External run.
+
+## Claims checklist
+
+The first manual proof should capture whether the issued access token contains claims that line up with Azure Health Data Services FHIR expectations:
+
+- `aud` matches the application audience configured for the trusted identity provider
+- `azp` or `appid` matches the backend client that FHIR is configured to trust
+- `scp` contains the expected SMART/backend scope information
+- `roles` is present or absent, and whether it appears instead of `scp`
+
+The most important risk to resolve is whether the direct token shape from either provider is acceptable to FHIR and the relevant Inferno backend-services tests.
+
+## Suggested proof sequence
+
+1. Generate or obtain the backend client assertion.
+2. Request a token directly from the chosen identity provider.
+3. Decode and save the token claims.
+4. Attempt a direct FHIR read with the issued access token.
+5. Record:
+   - token endpoint result,
+   - access token claims,
+   - FHIR response code/body,
+   - any mismatch with expected SMART backend behavior.
+
+## Go / no-go signal
+
+Treat the proof as a **go** only when all of the following are true:
+
+- The chosen identity provider issues a token successfully for the backend client.
+- The token claims match what FHIR validation requires.
+- Direct FHIR access succeeds with that token.
+- The claim shape looks compatible with the backend-services behaviors you need to demonstrate in Inferno.
+
+If you run both Entra External and standard Entra in parallel, compare:
+
+- `iss`
+- `aud`
+- `azp` or `appid`
+- `scp`
+- `roles`
+- direct FHIR response status
+- any difference in admin consent or app-registration requirements
+
+If the proof fails, capture whether the blocker is:
+
+- token issuance,
+- token claims,
+- FHIR identity-provider configuration,
+- or Inferno compatibility.
+
+## If the proof succeeds
+
+The next step should be a **separate branch** containing a very small handoff artifact for the vendor team, such as:
+
+- a script-first proof package, or
+- a tiny console sample that requests the token and calls FHIR directly.
+
+That follow-up branch should stay decoupled from `SMARTCustomOperations.AzureAuth`.

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/Run-MinimalSmartShim.py
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/Run-MinimalSmartShim.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import fnmatch
+import json
+import sqlite3
+import sys
+import time
+import urllib.parse
+import urllib.request
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+
+def b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def b64url_decode(value: str) -> bytes:
+    padding_len = (4 - len(value) % 4) % 4
+    return base64.urlsafe_b64decode(value + ("=" * padding_len))
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json_response(handler: BaseHTTPRequestHandler, status: int, payload: object) -> None:
+    body = json.dumps(payload, indent=2).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def build_rsa_public_jwk(public_key: rsa.RSAPublicKey) -> Dict[str, str]:
+    numbers = public_key.public_numbers()
+    n_bytes = numbers.n.to_bytes((numbers.n.bit_length() + 7) // 8, "big")
+    e_bytes = numbers.e.to_bytes((numbers.e.bit_length() + 7) // 8, "big")
+    jwk = {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "n": b64url_encode(n_bytes),
+        "e": b64url_encode(e_bytes),
+    }
+    canonical = json.dumps({"e": jwk["e"], "kty": jwk["kty"], "n": jwk["n"]}, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(canonical)
+    jwk["kid"] = b64url_encode(digest.finalize())
+    return jwk
+
+
+def load_or_create_signing_key(key_path: Path) -> Tuple[rsa.RSAPrivateKey, Dict[str, str]]:
+    if key_path.exists():
+        private_key = serialization.load_pem_private_key(key_path.read_bytes(), password=None)
+        if not isinstance(private_key, rsa.RSAPrivateKey):
+            raise ValueError("Shim signing key must be RSA.")
+    else:
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        key_path.write_bytes(
+            private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+    return private_key, build_rsa_public_jwk(private_key.public_key())
+
+
+def decode_jwt_unverified(token: str) -> Tuple[Dict[str, object], Dict[str, object], bytes]:
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("JWT must have exactly 3 segments.")
+    header = json.loads(b64url_decode(parts[0]))
+    payload = json.loads(b64url_decode(parts[1]))
+    signing_input = f"{parts[0]}.{parts[1]}".encode("utf-8")
+    signature = b64url_decode(parts[2])
+    return header, payload, signing_input + b"." + signature  # not used directly, but keeps interface stable
+
+
+def decode_jwt_parts(token: str) -> Tuple[Dict[str, object], Dict[str, object], bytes, bytes]:
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("JWT must have exactly 3 segments.")
+    header = json.loads(b64url_decode(parts[0]))
+    payload = json.loads(b64url_decode(parts[1]))
+    signing_input = f"{parts[0]}.{parts[1]}".encode("utf-8")
+    signature = b64url_decode(parts[2])
+    return header, payload, signing_input, signature
+
+
+def rsa_public_key_from_jwk(jwk: Dict[str, str]) -> rsa.RSAPublicKey:
+    n_value = int.from_bytes(b64url_decode(jwk["n"]), "big")
+    e_value = int.from_bytes(b64url_decode(jwk["e"]), "big")
+    return rsa.RSAPublicNumbers(e_value, n_value).public_key()
+
+
+def ec_public_key_from_jwk(jwk: Dict[str, str]) -> ec.EllipticCurvePublicKey:
+    curve_name = jwk.get("crv")
+    if curve_name != "P-384":
+        raise ValueError(f"Unsupported EC curve '{curve_name}'.")
+    curve = ec.SECP384R1()
+    x_value = int.from_bytes(b64url_decode(jwk["x"]), "big")
+    y_value = int.from_bytes(b64url_decode(jwk["y"]), "big")
+    return ec.EllipticCurvePublicNumbers(x_value, y_value, curve).public_key()
+
+
+def verify_signature(header: Dict[str, object], signing_input: bytes, signature: bytes, jwk: Dict[str, str]) -> None:
+    alg = header.get("alg")
+    if alg == "RS384":
+        public_key = rsa_public_key_from_jwk(jwk)
+        public_key.verify(signature, signing_input, padding.PKCS1v15(), hashes.SHA384())
+        return
+    if alg == "ES384":
+        public_key = ec_public_key_from_jwk(jwk)
+        public_key.verify(signature, signing_input, ec.ECDSA(hashes.SHA384()))
+        return
+    raise ValueError(f"Unsupported client assertion algorithm '{alg}'.")
+
+
+def fetch_json_url(url: str) -> Dict[str, object]:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+class ReplayStore:
+    def __init__(self, db_path: Path) -> None:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS used_jti (
+                client_id TEXT NOT NULL,
+                jti TEXT NOT NULL,
+                expires_at INTEGER NOT NULL,
+                PRIMARY KEY (client_id, jti)
+            )
+            """
+        )
+        self._conn.commit()
+
+    def reserve(self, client_id: str, jti: str, expires_at: int) -> bool:
+        now = int(time.time())
+        self._conn.execute("DELETE FROM used_jti WHERE expires_at < ?", (now,))
+        try:
+            self._conn.execute(
+                "INSERT INTO used_jti (client_id, jti, expires_at) VALUES (?, ?, ?)",
+                (client_id, jti, expires_at),
+            )
+            self._conn.commit()
+            return True
+        except sqlite3.IntegrityError:
+            return False
+
+
+class RegistrationStore:
+    def __init__(self, registrations_dir: Path) -> None:
+        self._registrations_dir = registrations_dir
+
+    def find_by_client_id(self, client_id: str) -> Dict[str, object]:
+        if not self._registrations_dir.exists():
+            raise FileNotFoundError(f"Registrations directory '{self._registrations_dir}' does not exist.")
+
+        for path in sorted(self._registrations_dir.glob("*.json")):
+            registration = load_json(path)
+            if not isinstance(registration, dict):
+                continue
+            if registration.get("clientId") == client_id and registration.get("enabled", True):
+                registration["_path"] = str(path)
+                return registration
+        raise KeyError(f"No enabled registration found for client_id '{client_id}'.")
+
+    def list_supported_scopes(self) -> List[str]:
+        scopes: List[str] = []
+        if not self._registrations_dir.exists():
+            return scopes
+        for path in sorted(self._registrations_dir.glob("*.json")):
+            registration = load_json(path)
+            if not isinstance(registration, dict) or not registration.get("enabled", True):
+                continue
+            scopes.extend(registration.get("allowedScopes", []))
+        return sorted(set(scopes))
+
+
+class ShimConfig:
+    def __init__(self, issuer: str, host: str, port: int, registrations_dir: Path, state_dir: Path, token_lifetime_seconds: int) -> None:
+        self.issuer = issuer.rstrip("/")
+        self.host = host
+        self.port = port
+        self.registrations_dir = registrations_dir
+        self.state_dir = state_dir
+        self.token_lifetime_seconds = token_lifetime_seconds
+        self.private_key, self.public_jwk = load_or_create_signing_key(state_dir / "shim-signing-key.pem")
+        self.replay_store = ReplayStore(state_dir / "shim-state.db")
+        self.registration_store = RegistrationStore(registrations_dir)
+
+    @property
+    def jwks(self) -> Dict[str, object]:
+        return {"keys": [self.public_jwk]}
+
+    @property
+    def token_endpoint(self) -> str:
+        return f"{self.issuer}/token"
+
+    @property
+    def openid_configuration(self) -> Dict[str, object]:
+        return {
+            "issuer": self.issuer,
+            "jwks_uri": f"{self.issuer}/jwks.json",
+            "token_endpoint": self.token_endpoint,
+            "grant_types_supported": ["client_credentials"],
+            "token_endpoint_auth_methods_supported": ["private_key_jwt"],
+            "token_endpoint_auth_signing_alg_values_supported": ["RS384", "ES384"],
+            "response_types_supported": ["token"],
+            "subject_types_supported": ["public"],
+            "scopes_supported": self.registration_store.list_supported_scopes(),
+            "capabilities": ["client-confidential-asymmetric"],
+        }
+
+
+def validate_requested_scope(registration: Dict[str, object], requested_scope: str) -> str:
+    allowed_scopes = registration.get("allowedScopes", [])
+    if not allowed_scopes:
+        return requested_scope
+
+    requested_parts = [item for item in requested_scope.split(" ") if item]
+    for requested in requested_parts:
+        if not any(fnmatch.fnmatch(requested, allowed) or fnmatch.fnmatch(allowed, requested) for allowed in allowed_scopes):
+            raise ValueError(f"Requested scope '{requested}' is not allowed for this client.")
+    return requested_scope
+
+
+def issue_token(config: ShimConfig, registration: Dict[str, object], client_id: str, scope: str) -> str:
+    now = int(time.time())
+    payload: Dict[str, object] = {
+        "iss": config.issuer,
+        "sub": client_id,
+        "aud": registration["fhirAudience"],
+        "azp": client_id,
+        "appid": client_id,
+        "scp": scope,
+        "iat": now,
+        "nbf": now,
+        "exp": now + config.token_lifetime_seconds,
+    }
+    if registration.get("fhirUser"):
+        payload["fhirUser"] = registration["fhirUser"]
+
+    header = {
+        "alg": "RS256",
+        "typ": "JWT",
+        "kid": config.public_jwk["kid"],
+    }
+    encoded_header = b64url_encode(json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    encoded_payload = b64url_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    signing_input = f"{encoded_header}.{encoded_payload}".encode("utf-8")
+    signature = config.private_key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    return f"{encoded_header}.{encoded_payload}.{b64url_encode(signature)}"
+
+
+def validate_client_assertion(config: ShimConfig, registration: Dict[str, object], client_assertion: str) -> str:
+    header, payload, signing_input, signature = decode_jwt_parts(client_assertion)
+
+    client_id = str(payload.get("sub", ""))
+    issuer = str(payload.get("iss", ""))
+    if not client_id or issuer != client_id:
+        raise ValueError("SMART client_assertion must use identical iss and sub values.")
+
+    if client_id != registration["clientId"]:
+        raise ValueError("Registration clientId does not match the client_assertion subject.")
+
+    if str(payload.get("aud", "")) != config.token_endpoint:
+        raise ValueError("client_assertion aud must equal the shim token endpoint.")
+
+    exp = int(payload.get("exp", 0))
+    if exp <= int(time.time()):
+        raise ValueError("client_assertion is expired.")
+
+    jti = str(payload.get("jti", ""))
+    if not jti:
+        raise ValueError("client_assertion must include jti.")
+
+    jku = header.get("jku")
+    registered_jwks_uri = registration.get("jwksUri")
+    if jku:
+        if not registered_jwks_uri or str(jku) != str(registered_jwks_uri):
+            raise ValueError("client_assertion jku does not match the registered jwksUri.")
+
+    if registration.get("jwks"):
+        jwks = registration["jwks"]
+    elif registered_jwks_uri:
+        jwks = fetch_json_url(str(registered_jwks_uri))
+    else:
+        raise ValueError("Registration must include jwksUri or jwks.")
+
+    alg = str(header.get("alg", ""))
+    kid = str(header.get("kid", ""))
+    if alg not in {"RS384", "ES384"}:
+        raise ValueError(f"Unsupported client_assertion algorithm '{alg}'.")
+    if not kid:
+        raise ValueError("client_assertion must include kid.")
+
+    candidate_keys = []
+    for key in jwks.get("keys", []):
+        if key.get("kid") != kid:
+            continue
+        if alg.startswith("RS") and key.get("kty") != "RSA":
+            continue
+        if alg.startswith("ES") and key.get("kty") != "EC":
+            continue
+        candidate_keys.append(key)
+
+    if len(candidate_keys) != 1:
+        raise ValueError("Registration JWKS did not resolve to exactly one candidate signing key.")
+
+    verify_signature(header, signing_input, signature, candidate_keys[0])
+
+    if not config.replay_store.reserve(client_id, jti, exp):
+        raise ValueError("client_assertion jti has already been used.")
+
+    return client_id
+
+
+class ShimHandler(BaseHTTPRequestHandler):
+    server_version = "MinimalSmartShim/0.1"
+
+    @property
+    def config(self) -> ShimConfig:
+        return self.server.config  # type: ignore[attr-defined]
+
+    def log_message(self, format: str, *args: object) -> None:
+        sys.stderr.write("%s - - [%s] %s\n" % (self.client_address[0], self.log_date_time_string(), format % args))
+
+    def do_GET(self) -> None:
+        if self.path == "/.well-known/openid-configuration":
+            write_json_response(self, HTTPStatus.OK, self.config.openid_configuration)
+            return
+        if self.path == "/jwks.json":
+            write_json_response(self, HTTPStatus.OK, self.config.jwks)
+            return
+        if self.path == "/":
+            write_json_response(
+                self,
+                HTTPStatus.OK,
+                {
+                    "service": "minimal-smart-shim",
+                    "issuer": self.config.issuer,
+                    "tokenEndpoint": self.config.token_endpoint,
+                    "registrationsDirectory": str(self.config.registrations_dir),
+                },
+            )
+            return
+        write_json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def do_POST(self) -> None:
+        if self.path != "/token":
+            write_json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+
+        content_type = self.headers.get("Content-Type", "")
+        if not content_type.startswith("application/x-www-form-urlencoded"):
+            write_json_response(self, HTTPStatus.BAD_REQUEST, {"error": "invalid_request", "error_description": "Content-Type must be application/x-www-form-urlencoded."})
+            return
+
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length).decode("utf-8")
+        form = urllib.parse.parse_qs(body, keep_blank_values=False)
+        grant_type = form.get("grant_type", [""])[0]
+        assertion_type = form.get("client_assertion_type", [""])[0]
+        client_assertion = form.get("client_assertion", [""])[0]
+        scope = form.get("scope", [""])[0]
+
+        if grant_type != "client_credentials":
+            write_json_response(self, HTTPStatus.BAD_REQUEST, {"error": "unsupported_grant_type", "error_description": "Only client_credentials is supported."})
+            return
+        if assertion_type != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer":
+            write_json_response(self, HTTPStatus.BAD_REQUEST, {"error": "invalid_request", "error_description": "client_assertion_type must be urn:ietf:params:oauth:client-assertion-type:jwt-bearer."})
+            return
+        if not client_assertion:
+            write_json_response(self, HTTPStatus.BAD_REQUEST, {"error": "invalid_request", "error_description": "client_assertion is required."})
+            return
+        if not scope:
+            write_json_response(self, HTTPStatus.BAD_REQUEST, {"error": "invalid_scope", "error_description": "scope is required."})
+            return
+
+        try:
+            _, payload, _, _ = decode_jwt_parts(client_assertion)
+            client_id = str(payload.get("sub", ""))
+            registration = self.config.registration_store.find_by_client_id(client_id)
+            validate_client_assertion(self.config, registration, client_assertion)
+            granted_scope = validate_requested_scope(registration, scope)
+            access_token = issue_token(self.config, registration, client_id, granted_scope)
+        except KeyError as exc:
+            write_json_response(self, HTTPStatus.UNAUTHORIZED, {"error": "invalid_client", "error_description": str(exc)})
+            return
+        except FileNotFoundError as exc:
+            write_json_response(self, HTTPStatus.INTERNAL_SERVER_ERROR, {"error": "server_error", "error_description": str(exc)})
+            return
+        except ValueError as exc:
+            description = str(exc)
+            if "scope" in description:
+                write_json_response(self, HTTPStatus.BAD_REQUEST, {"error": "invalid_scope", "error_description": description})
+                return
+            write_json_response(self, HTTPStatus.UNAUTHORIZED, {"error": "invalid_client", "error_description": description})
+            return
+        except urllib.error.URLError as exc:
+            write_json_response(self, HTTPStatus.UNAUTHORIZED, {"error": "invalid_client", "error_description": f"Unable to fetch client JWKS: {exc.reason}"})
+            return
+
+        write_json_response(
+            self,
+            HTTPStatus.OK,
+            {
+                "token_type": "Bearer",
+                "expires_in": self.config.token_lifetime_seconds,
+                "access_token": access_token,
+                "scope": granted_scope,
+            },
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a minimal SMART-aware shim proof service.")
+    parser.add_argument("--issuer", default="http://127.0.0.1:8765", help="Public issuer URL to advertise in discovery and token claims.")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind locally.")
+    parser.add_argument("--port", type=int, default=8765, help="Local port to bind.")
+    parser.add_argument(
+        "--registrations-dir",
+        default=str(Path(__file__).resolve().parent / "registrations"),
+        help="Directory containing JSON backend-client registrations.",
+    )
+    parser.add_argument(
+        "--state-dir",
+        default=str(Path(__file__).resolve().parent / ".shim-state"),
+        help="Directory used for shim signing keys and replay state.",
+    )
+    parser.add_argument("--token-lifetime-seconds", type=int, default=3600, help="Lifetime of issued shim access tokens.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = ShimConfig(
+        issuer=args.issuer,
+        host=args.host,
+        port=args.port,
+        registrations_dir=Path(args.registrations_dir).resolve(),
+        state_dir=Path(args.state_dir).resolve(),
+        token_lifetime_seconds=args.token_lifetime_seconds,
+    )
+    server = ThreadingHTTPServer((config.host, config.port), ShimHandler)
+    server.config = config  # type: ignore[attr-defined]
+    print(json.dumps({"issuer": config.issuer, "tokenEndpoint": config.token_endpoint, "jwksUri": f"{config.issuer}/jwks.json"}, indent=2))
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        raise SystemExit(0)

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/SHIM_DIRECT_TRUST_APPROACH.md
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/SHIM_DIRECT_TRUST_APPROACH.md
@@ -1,0 +1,221 @@
+# Possible approach: shim IdP trusted directly by FHIR
+
+## Goal
+
+Provide a path for SMART on FHIR asymmetric client authentication that:
+
+- works with Inferno's `jwks_uri` / `private_key_jwt` model,
+- avoids forcing Inferno into native Entra certificate semantics,
+- and avoids the current Entra client-secret exchange pattern for backend services.
+
+This option uses a **shim identity provider / authorization component** as the SMART-aware front door, and has the FHIR service trust that shim **directly**.
+
+## Why this option exists
+
+The investigation showed:
+
+- SMART allows manual client public-key registration through **JWKS URL** or **JWKS directly**
+- Inferno uses the SMART asymmetric client profile (`jwks_uri`, `RS384` / `ES384`)
+- Entra can store uploaded certs, but it did **not** accept Inferno's actual assertion after uploading a certificate derived from Inferno's RSA JWKS
+
+So the mismatch is not only registration. The mismatch is that:
+
+- **SMART** expects JWKS-based client trust and `private_key_jwt` validation
+- **Entra** expects certificate-based app credential validation
+
+This makes a SMART-aware shim a more natural place to handle Inferno-style client authentication.
+
+## Target architecture
+
+```mermaid
+sequenceDiagram
+    participant Inferno as Inferno / Backend Client
+    participant Shim as SMART Auth Shim
+    participant FHIR as Azure FHIR Service
+
+    Inferno->>Shim: POST /token with client_assertion
+    Note over Inferno,Shim: private_key_jwt signed with RS384 or ES384
+    Shim->>Shim: Resolve registered JWKS / jwks_uri
+    Shim->>Shim: Validate kid, jku/jwks_uri, alg, aud, jti, exp
+    Shim->>Shim: Apply client registration + access policy
+    Shim-->>Inferno: Access token
+    Inferno->>FHIR: FHIR request with shim-issued token
+    FHIR->>FHIR: Validate token against trusted shim authority
+    FHIR-->>Inferno: FHIR response
+```
+
+## High-level design
+
+The shim becomes the **authorization server for backend-services auth**. It is responsible for:
+
+1. **Client registration**
+   - store `client_id`
+   - store `jwks_uri` or JWKS
+   - store allowed scopes / allowed data actions
+   - optionally store tenant or environment metadata
+
+2. **Asymmetric client authentication**
+   - accept SMART `private_key_jwt`
+   - support `RS384` and `ES384`
+   - validate `kid`
+   - validate `jku` against the registration-time whitelist when present
+   - dereference `jwks_uri` or use stored JWKS when `jku` is absent
+   - validate `iss`, `sub`, `aud`, `exp`, `jti`
+
+3. **Token issuance**
+   - issue an access token that the FHIR service trusts directly
+   - shape claims to match what Azure FHIR expects from a trusted external identity provider
+
+4. **Key rotation handling**
+   - respect the client's JWKS cache headers
+   - refresh key material on rotation without manual re-registration when a stable `jwks_uri` is used
+
+## Where the existing test IDP shim helps
+
+The script at:
+
+`../fhir-paas/tools/scripts/Create-TestThirdPartyToken.ps1`
+
+already provides useful building blocks:
+
+- mock OIDC issuer hosting
+- JWKS publication
+- token signing
+- deployable App Service footprint
+
+It is **not** sufficient as-is, because it currently behaves like a simple external token issuer and not a SMART backend authorization server.
+
+## What would need to change in the shim
+
+### Required additions
+
+1. **SMART-style `/token` endpoint**
+   - accept `grant_type=client_credentials`
+   - accept `client_assertion_type`
+   - accept `client_assertion`
+   - return SMART-compatible OAuth error responses such as `invalid_client`
+
+2. **Registration store**
+   - persistent store for registered backend clients
+   - manual registration UI/script/process is acceptable
+   - should support:
+     - `client_id`
+     - `jwks_uri`
+     - fallback JWKS
+     - allowed scopes
+     - optional metadata like environment, contact, expiry
+
+3. **SMART asymmetric validation**
+   - verify `RS384` and `ES384`
+   - enforce `aud = token endpoint`
+   - enforce one-time `jti`
+   - support `jku` whitelist checks
+   - support dereferencing JWKS at runtime
+
+4. **Token issuance aligned to FHIR**
+   - issue JWTs from the shim's own authority
+   - publish shim OIDC metadata and JWKS
+   - ensure FHIR is configured to trust the shim authority
+   - include claims that FHIR expects for direct trust
+
+### Likely claim requirements to satisfy FHIR
+
+The exact token shape should be validated in a prototype, but the shim-issued token will likely need to include:
+
+- `iss` = shim issuer URL
+- `aud` = FHIR audience configured for the trusted identity provider
+- `azp` or `appid` = registered backend client identifier
+- `scp` = allowed SMART/backend scopes
+
+If Azure FHIR requires more than this for app-only flows, that gap should be validated early in the prototype.
+
+## FHIR integration model
+
+This option assumes the FHIR service is configured to trust the shim as an **external OIDC identity provider**.
+
+That means the shim must expose:
+
+- `/.well-known/openid-configuration`
+- `jwks_uri`
+- stable signing keys with rotation support
+
+And the FHIR service must be configured with:
+
+- shim `authority`
+- shim application/client mapping
+- shim `audience`
+- allowed data actions
+
+## Benefits of this approach
+
+1. **Matches SMART more naturally**
+   - JWKS registration and `private_key_jwt` validation live in a SMART-aware component
+
+2. **Supports Inferno's model**
+   - `jwks_uri`
+   - `RS384` / `ES384`
+   - runtime key resolution
+
+3. **Decouples client auth from Entra limitations**
+   - no need to coerce Inferno into Entra's cert identity model
+
+4. **Eliminates the current secret exchange pattern**
+   - no per-client Entra secret retrieval from Key Vault
+
+## Risks and open questions
+
+1. **FHIR claim compatibility**
+   - the shim can issue its own JWTs, but we still need to prove the exact claim shape Azure FHIR accepts
+
+2. **Operational ownership**
+   - this introduces a new auth component that must be operated, monitored, and secured
+
+3. **Replay protection and token security**
+   - `jti` replay detection and signing-key hygiene become the shim's responsibility
+
+4. **Conformance and discovery**
+   - the SMART discovery metadata served through APIM must accurately describe the shim-backed token endpoint
+
+## Recommended prototype plan
+
+### Phase 1: minimal proof
+
+Build a small shim that:
+
+1. hosts OIDC metadata and JWKS,
+2. supports one manually registered backend client,
+3. validates `RS384` Inferno-style assertions,
+4. issues a signed access token with the expected FHIR claims,
+5. calls FHIR directly with that token.
+
+Success criteria:
+
+- Inferno client assertion is accepted by the shim
+- shim-issued token is accepted by FHIR
+- no Entra client-secret exchange is involved
+
+### Phase 2: Inferno end-to-end
+
+Wire Inferno to the shim `/token` endpoint and prove:
+
+- registration with `jwks_uri`
+- successful token issuance
+- successful FHIR access
+- relevant Inferno backend-services tests pass
+
+## Suggested implementation boundary
+
+The cleanest boundary is:
+
+- keep Entra for user-facing interactive auth where it already works well
+- use the shim only for backend-services asymmetric auth
+
+That minimizes blast radius while solving the specific mismatch uncovered in this investigation.
+
+## Bottom line
+
+This is the most plausible path if the requirement is:
+
+> Support Inferno and SMART asymmetric backend-services auth without relying on the current Entra secret-exchange workaround.
+
+It does **not** remove custom auth logic entirely, but it moves that logic into a component whose trust model matches SMART much better than native Entra client authentication does.

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/SHIM_IMPLEMENTATION_OPTIONS.md
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/SHIM_IMPLEMENTATION_OPTIONS.md
@@ -1,0 +1,315 @@
+# SMART-aware shim implementation options
+
+## Goal
+
+Describe what the "shim" actually is if we promote the current broker concept into a real SMART-aware issuer that Azure FHIR trusts directly.
+
+This note focuses on one design question:
+
+> Can the shim just be static file hosting for OIDC metadata and JWKS, or does it need to be a real authorization service?
+
+## Short answer
+
+Your idea is **partly right**, but only for the **issuer-facing public artifacts**:
+
+- `/.well-known/openid-configuration`
+- the shim's own `jwks_uri`
+- optional static registration/config files
+
+Those pieces can absolutely live in static storage.
+
+What **cannot** be static is the SMART backend authentication path itself, because the shim still needs to:
+
+1. accept `POST /token`,
+2. determine which backend client is calling,
+3. load that client's registered `jwks_uri` or JWKS,
+4. validate the inbound `private_key_jwt`,
+5. enforce `aud`, `kid`, `jku`, `exp`, and `jti`,
+6. apply the client's allowed scopes / data actions,
+7. issue a new access token from the shim issuer.
+
+So the real split is:
+
+- **public issuer metadata can be static**
+- **client authentication and token issuance must be dynamic**
+
+## How this differs from my earlier thought
+
+Your proposed shape sounds like:
+
+```text
+Static storage
+  ├─ /.well-known/openid-configuration
+  ├─ /jwks.json
+  └─ maybe some client registration files
+```
+
+My earlier mental model was:
+
+```text
+SMART-aware shim
+  ├─ public issuer metadata (can be static)
+  ├─ token endpoint (dynamic)
+  ├─ client registration store
+  ├─ replay protection store
+  ├─ client JWKS fetch/cache logic
+  └─ token signing / issuance
+```
+
+So the difference is not really philosophical. It is mostly about **where the line is**:
+
+- your idea covers the **issuer shell**
+- my idea includes the **authorization logic behind the shell**
+
+## Why static-only is not enough
+
+If the shim is only static files, it can prove:
+
+- the shim has an issuer URL,
+- the shim publishes signing keys,
+- Azure FHIR can discover and trust the shim authority.
+
+But it cannot do the most important SMART work:
+
+- validate Inferno's `private_key_jwt`
+- bind a request to a specific registered `client_id`
+- fetch and validate the client's JWKS
+- enforce one-time-use `jti`
+- mint a token for that specific client
+
+That means static-only hosting is **an issuer facade**, not a full backend-services auth solution.
+
+## Recommended implementation options
+
+## Option 1 - Static metadata + minimal token function
+
+### What it is
+
+Use static hosting for:
+
+- `/.well-known/openid-configuration`
+- shim `jwks.json`
+- optional per-client registration documents
+
+Use a very small dynamic component for:
+
+- `/token`
+- client registration lookup
+- client assertion validation
+- replay detection
+- token issuance
+
+### Example shape
+
+```text
+Storage Account / Blob / Static Web App
+  ├─ /.well-known/openid-configuration
+  ├─ /jwks.json
+  └─ /registrations/{client_id}.json   (optional, private or admin-managed)
+
+Azure Function / App Service
+  └─ POST /token
+       ├─ lookup client registration
+       ├─ fetch client jwks_uri / JWKS
+       ├─ validate SMART assertion
+       ├─ enforce jti replay protection
+       └─ issue shim token
+```
+
+### Why this is attractive
+
+- closest to your "simple shim" idea
+- low operational footprint
+- keeps public OIDC artifacts simple and inspectable
+- dynamic logic stays limited to one endpoint
+
+### Main drawback
+
+- still needs a real auth function behind `/token`
+- still needs secure signing-key handling
+- still needs nonce/replay storage
+
+### Recommendation
+
+This is the **best minimal viable design**.
+
+## Option 2 - File-backed registration + token service
+
+### What it is
+
+Same as Option 1, but make the registration store explicit and admin-managed.
+
+For example, store one config file per client:
+
+```json
+{
+  "clientId": "inferno-backend-client",
+  "jwksUri": "https://inferno.healthit.gov/suites/custom/smart_stu2/.well-known/jwks.json",
+  "allowedScopes": ["system/*.rs"],
+  "allowedDataActions": ["Read"],
+  "status": "active"
+}
+```
+
+### Example shape
+
+```text
+Private storage/config repo
+  └─ registrations/
+       ├─ client-a.json
+       ├─ client-b.json
+       └─ client-c.json
+
+Token service
+  └─ loads config for requested client_id
+```
+
+### Why this is attractive
+
+- simple admin model
+- easy to reason about
+- no separate database required at first
+- good fit for manual onboarding
+
+### Main drawback
+
+- file-based updates are clumsy at scale
+- concurrent updates / audit trail become harder
+- replay detection still needs a dynamic store
+
+### Recommendation
+
+Good for an early prototype or low-volume manual onboarding.
+
+## Option 3 - Full SMART authorization service
+
+### What it is
+
+A more complete service with:
+
+- dynamic client registration storage
+- optional admin API or portal
+- token issuance
+- replay store
+- JWKS cache/refresh logic
+- richer policy and telemetry
+
+### Example shape
+
+```text
+Shim API
+  ├─ GET /.well-known/openid-configuration
+  ├─ GET /jwks.json
+  ├─ POST /token
+  └─ POST /admin/clients
+
+Backing services
+  ├─ client registry
+  ├─ replay/nonce store
+  ├─ audit log
+  └─ signing key store
+```
+
+### Why this is attractive
+
+- clean long-term architecture
+- better control and auditability
+- easier to support multiple clients and policies
+- better path to production hardening
+
+### Main drawback
+
+- biggest implementation and operational burden
+- more moving parts than needed for a first proof
+
+### Recommendation
+
+Best long-term design if this becomes a supported product feature, but too heavy for the first proof.
+
+## Option 4 - Static public issuer + broker back to Entra/External
+
+### What it is
+
+Keep the shim public surface small, but instead of issuing its own final token for FHIR, the shim validates the SMART assertion and then exchanges into Entra / Entra External.
+
+### Why it exists
+
+This is basically a cleaner version of the current sample:
+
+- the shim handles SMART auth
+- Entra still issues the final token
+
+### Why it is weaker than direct trust
+
+- still a token exchange pattern
+- still tied to Entra/External constraints
+- does not fully remove the design you were trying to replace
+
+### Recommendation
+
+Only worth doing if direct FHIR trust turns out to be blocked.
+
+## Best way to think about the shim
+
+The shim is **not just an OIDC metadata host**.
+
+It is really two things:
+
+1. **An issuer surface**
+   - openid configuration
+   - issuer JWKS
+   - stable authority URL
+
+2. **A SMART backend authorization engine**
+   - per-client registration
+   - client assertion validation
+   - replay protection
+   - token issuance
+
+The public issuer surface can be mostly static.
+The authorization engine cannot.
+
+## Suggested prototype path
+
+If the goal is to keep the shim as simple as possible while still proving the architecture, the best first step is:
+
+1. **Option 1** as the prototype
+2. with **Option 2-style file-backed client registration**
+
+That gives:
+
+- static OIDC metadata
+- static shim JWKS
+- manual client onboarding
+- one small dynamic `/token` component
+- no dependency on Entra token exchange
+
+## Proposed first implementation boundary
+
+### Static
+
+- `/.well-known/openid-configuration`
+- `/jwks.json`
+- optional registration files
+
+### Dynamic
+
+- `POST /token`
+- registration lookup
+- client JWKS fetch/cache
+- replay store
+- token issuance
+
+## Bottom line
+
+If by "shim" we mean:
+
+> a tiny issuer that only serves static metadata and keys
+
+then it is **not enough**.
+
+If by "shim" we mean:
+
+> a tiny SMART-aware token service with static public metadata
+
+then yes — that is very close to what I think is the best minimal path.

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/Test-BackendDirectAuth.ps1
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/Test-BackendDirectAuth.ps1
@@ -1,0 +1,270 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TokenEndpoint,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ClientId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Scope,
+
+    [Parameter(Mandatory = $false)]
+    [string]$FhirAudience,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ClientAssertion,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ClientAssertionFile,
+
+    [Parameter(Mandatory = $false)]
+    [string]$FhirBaseUrl,
+
+    [Parameter(Mandatory = $false)]
+    [string]$FhirRelativePath = "Patient?_count=1",
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputDirectory
+)
+
+function Resolve-Assertion {
+    param(
+        [string]$InlineAssertion,
+        [string]$AssertionFile
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($InlineAssertion) -and -not [string]::IsNullOrWhiteSpace($AssertionFile)) {
+        throw "Provide either ClientAssertion or ClientAssertionFile, not both."
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($InlineAssertion)) {
+        return $InlineAssertion.Trim()
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($AssertionFile)) {
+        if (-not (Test-Path -Path $AssertionFile -PathType Leaf)) {
+            throw "Client assertion file not found: $AssertionFile"
+        }
+
+        return (Get-Content -Path $AssertionFile -Raw).Trim()
+    }
+
+    throw "ClientAssertion or ClientAssertionFile is required."
+}
+
+function Resolve-Scope {
+    param(
+        [string]$RequestedScope,
+        [string]$Audience
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedScope)) {
+        return $RequestedScope.Trim()
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Audience)) {
+        throw "Provide Scope or FhirAudience."
+    }
+
+    return "$($Audience.TrimEnd('/'))/.default"
+}
+
+function ConvertFrom-Base64Url {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InputString
+    )
+
+    $padded = $InputString.Replace('-', '+').Replace('_', '/')
+
+    switch ($padded.Length % 4) {
+        2 { $padded += '==' }
+        3 { $padded += '=' }
+    }
+
+    return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($padded))
+}
+
+function ConvertFrom-JwtSegment {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Segment
+    )
+
+    return (ConvertFrom-Base64Url -InputString $Segment) | ConvertFrom-Json
+}
+
+function Get-JwtParts {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Token
+    )
+
+    $segments = $Token.Split('.')
+    if ($segments.Length -lt 2) {
+        throw "Token is not a valid JWT."
+    }
+
+    return [PSCustomObject]@{
+        Header  = ConvertFrom-JwtSegment -Segment $segments[0]
+        Payload = ConvertFrom-JwtSegment -Segment $segments[1]
+    }
+}
+
+function Join-UriParts {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BaseUrl,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath
+    )
+
+    return "$($BaseUrl.TrimEnd('/'))/$($RelativePath.TrimStart('/'))"
+}
+
+function Write-OptionalJsonFile {
+    param(
+        [string]$Directory,
+        [string]$FileName,
+        [object]$Content
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Directory)) {
+        return
+    }
+
+    if (-not (Test-Path -Path $Directory -PathType Container)) {
+        New-Item -ItemType Directory -Path $Directory -Force | Out-Null
+    }
+
+    $path = Join-Path -Path $Directory -ChildPath $FileName
+    $Content | ConvertTo-Json -Depth 20 | Set-Content -Path $path
+}
+
+$resolvedAssertion = Resolve-Assertion -InlineAssertion $ClientAssertion -AssertionFile $ClientAssertionFile
+$resolvedScope = Resolve-Scope -RequestedScope $Scope -Audience $FhirAudience
+
+$tokenRequestBody = @{
+    grant_type            = "client_credentials"
+    client_id             = $ClientId
+    scope                 = $resolvedScope
+    client_assertion_type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+    client_assertion      = $resolvedAssertion
+}
+
+Write-Host "Requesting backend access token directly from $TokenEndpoint"
+$tokenResponse = Invoke-RestMethod `
+    -Method Post `
+    -Uri $TokenEndpoint `
+    -ContentType "application/x-www-form-urlencoded" `
+    -Body $tokenRequestBody
+
+if ([string]::IsNullOrWhiteSpace($tokenResponse.access_token)) {
+    throw "Token response did not contain access_token."
+}
+
+$decodedAccessToken = Get-JwtParts -Token $tokenResponse.access_token
+$claims = $decodedAccessToken.Payload
+
+$claimSummary = [PSCustomObject]@{
+    iss               = $claims.iss
+    aud               = $claims.aud
+    azp               = $claims.azp
+    appid             = $claims.appid
+    sub               = $claims.sub
+    scp               = $claims.scp
+    roles             = $claims.roles
+    tid               = $claims.tid
+    exp               = $claims.exp
+    nbf               = $claims.nbf
+    clientIdMatchHint = if ($claims.azp) { "azp" } elseif ($claims.appid) { "appid" } else { $null }
+}
+
+$claimWarnings = [System.Collections.Generic.List[string]]::new()
+if ([string]::IsNullOrWhiteSpace($claims.aud)) {
+    $claimWarnings.Add("Missing aud claim.")
+}
+if ([string]::IsNullOrWhiteSpace($claims.azp) -and [string]::IsNullOrWhiteSpace($claims.appid)) {
+    $claimWarnings.Add("Missing azp/appid claim. FHIR smartIdentityProviders validation depends on one of these.")
+}
+if ([string]::IsNullOrWhiteSpace($claims.scp)) {
+    $claimWarnings.Add("Missing scp claim. This is a known risk for app-only tokens and should be checked against FHIR and Inferno expectations.")
+}
+if ($claims.roles) {
+    $claimWarnings.Add("roles claim is present. Confirm whether FHIR accepts this instead of scp for the direct backend scenario.")
+}
+
+$fhirResult = $null
+if (-not [string]::IsNullOrWhiteSpace($FhirBaseUrl)) {
+    $fhirTestUri = Join-UriParts -BaseUrl $FhirBaseUrl -RelativePath $FhirRelativePath
+    Write-Host "Calling FHIR endpoint $fhirTestUri"
+
+    try {
+        $fhirResponse = Invoke-WebRequest `
+            -Method Get `
+            -Uri $fhirTestUri `
+            -Headers @{
+                Authorization = "Bearer $($tokenResponse.access_token)"
+                Accept        = "application/fhir+json"
+            }
+
+        $fhirResult = [PSCustomObject]@{
+            requestUri  = $fhirTestUri
+            statusCode  = [int]$fhirResponse.StatusCode
+            succeeded   = $true
+            responseBody = $fhirResponse.Content
+        }
+    }
+    catch {
+        $response = $_.Exception.Response
+        $statusCode = $null
+        $responseBody = $null
+
+        if ($response) {
+            $statusCode = [int]$response.StatusCode
+            if ($response.PSObject.Properties.Name -contains "Content" -and $response.Content) {
+                $responseBody = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+            }
+            elseif ($response.PSObject.Methods.Name -contains "GetResponseStream") {
+                $stream = $response.GetResponseStream()
+                if ($stream) {
+                    $reader = New-Object System.IO.StreamReader($stream)
+                    $responseBody = $reader.ReadToEnd()
+                    $reader.Dispose()
+                }
+            }
+        }
+
+        $fhirResult = [PSCustomObject]@{
+            requestUri   = $fhirTestUri
+            statusCode   = $statusCode
+            succeeded    = $false
+            responseBody = $responseBody
+        }
+    }
+}
+
+$summary = [PSCustomObject]@{
+    tokenEndpoint      = $TokenEndpoint
+    clientId           = $ClientId
+    requestedScope     = $resolvedScope
+    tokenType          = $tokenResponse.token_type
+    expiresIn          = $tokenResponse.expires_in
+    claims             = $claimSummary
+    claimWarnings      = $claimWarnings
+    fhirValidation     = $fhirResult
+}
+
+Write-OptionalJsonFile -Directory $OutputDirectory -FileName "token-response.json" -Content $tokenResponse
+Write-OptionalJsonFile -Directory $OutputDirectory -FileName "access-token-header.json" -Content $decodedAccessToken.Header
+Write-OptionalJsonFile -Directory $OutputDirectory -FileName "access-token-claims.json" -Content $claims
+Write-OptionalJsonFile -Directory $OutputDirectory -FileName "proof-summary.json" -Content $summary
+if ($fhirResult) {
+    Write-OptionalJsonFile -Directory $OutputDirectory -FileName "fhir-result.json" -Content $fhirResult
+}
+
+Write-Host ""
+Write-Host "=== Direct backend auth proof summary ==="
+$summary | ConvertTo-Json -Depth 10

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/direct-backend-auth-entra.http
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/direct-backend-auth-entra.http
@@ -1,0 +1,23 @@
+@token_endpoint = https://login.microsoftonline.com/<your-tenant-id>/oauth2/v2.0/token
+@client_id = <backend-client-id>
+@scope = api://<your-fhir-resource-app-id>/.default
+@client_assertion = <paste-client-assertion-here>
+@fhir_base_url = https://<your-fhir-service>.fhir.azurehealthcareapis.com
+
+### Request a backend token directly from a standard Entra tenant
+# @name getDirectToken
+POST {{token_endpoint}}
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&
+client_id={{client_id}}&
+scope={{scope}}&
+client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&
+client_assertion={{client_assertion}}
+
+### Use the returned token directly against the FHIR service
+GET {{fhir_base_url}}/Patient?_count=1
+Authorization: Bearer {{getDirectToken.response.body.$.access_token}}
+Accept: application/fhir+json
+
+### Optional: paste the access token from the first response into jwt.ms to inspect iss/aud/azp|appid/scp/roles.

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/direct-backend-auth.http
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/direct-backend-auth.http
@@ -1,0 +1,24 @@
+@token_endpoint = https://<your-tenant>.ciamlogin.com/<your-tenant-id>/oauth2/v2.0/token
+@client_id = <backend-client-id>
+@scope = api://<your-fhir-resource-app-id>/.default
+@client_assertion = <paste-client-assertion-here>
+@fhir_base_url = https://<your-fhir-service>.fhir.azurehealthcareapis.com
+
+### Request a backend token directly from Entra External
+# @name getDirectToken
+POST {{token_endpoint}}
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&
+client_id={{client_id}}&
+scope={{scope}}&
+client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&
+client_assertion={{client_assertion}}
+
+### Use the returned token directly against the FHIR service
+GET {{fhir_base_url}}/Patient?_count=1
+Authorization: Bearer {{getDirectToken.response.body.$.access_token}}
+Accept: application/fhir+json
+
+### Optional: paste the access token from the first response into jwt.ms to inspect iss/aud/azp|appid/scp/roles.
+

--- a/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/registrations/inferno-client.template.json
+++ b/samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/registrations/inferno-client.template.json
@@ -1,0 +1,15 @@
+{
+  "name": "inferno-backend-client-template",
+  "enabled": true,
+  "clientId": "__PASTE_INFERNO_CLIENT_ID_OR_REGISTRATION_TOKEN__",
+  "jwksUri": "https://inferno.healthit.gov/suites/custom/smart_stu2/.well-known/jwks.json",
+  "allowedScopes": [
+    "system/*.r",
+    "system/*.rs"
+  ],
+  "allowedDataActions": [
+    "Read"
+  ],
+  "fhirAudience": "api://__YOUR_FHIR_RESOURCE_APP_ID__",
+  "fhirUser": "Device/inferno-backend-client"
+}


### PR DESCRIPTION
## Summary
- add a minimal SMART-aware shim proof service under the backend auth proof kit
- add file-backed backend client registration for direct-trust experiments
- add a static Inferno OIDC/JWKS issuer package generator for narrow trust tests
- document how the shim differs from the current Entra secret-exchange bridge and how to configure Azure FHIR direct trust

## What this PR proves
- static OIDC discovery + shim JWKS publication
- dynamic POST /token handling for SMART private_key_jwt
- inbound RS384 / ES384 client assertion validation
- per-client JWKS binding instead of a shared key pool
- local persistent jti replay protection
- shim-issued JWTs shaped for Azure FHIR direct-trust experiments

## Deliberate limitations
- proof-only implementation, not a production-ready authorization server
- local replay store only
- no admin UI or automated client registration
- no default sample cutover from the existing Entra bridge
- no workload identity federation path in this implementation

## Files of interest
- samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/Run-MinimalSmartShim.py
- samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/registrations/inferno-client.template.json
- samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/Prepare-InfernoJwksUploadArtifacts.py
- samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/README.md
- samples/patientandpopulationservices-smartonfhir-oncg10-smart-v1/scripts/backend-direct-auth-proof/SHIM_IMPLEMENTATION_OPTIONS.md
